### PR TITLE
Fix duplicated virtualenv prompt on Clearance theme

### DIFF
--- a/themes/clearance/fish_prompt.fish
+++ b/themes/clearance/fish_prompt.fish
@@ -31,6 +31,7 @@ function fish_prompt
   echo -e ''
 
   # Display [venvname] if in a virtualenv
+  set -gx VIRTUAL_ENV_DISABLE_PROMPT 1
   if set -q VIRTUAL_ENV
       echo -n -s (set_color -b cyan black) '[' (basename "$VIRTUAL_ENV") ']' $normal ' '
   end


### PR DESCRIPTION
When using the Clearance theme inside an activated virtualenv, both the theme and the virtualenv activation script show a prompt indicating the name of the virtualenv prompt.

This pull request disables virtualenv's prompt, leaving only the theme's.