### PR TITLE
Add red-snapper theme

### DIFF
--- a/themes/red-snapper/LICENSE
+++ b/themes/red-snapper/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Zura Guerra
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/themes/red-snapper/README.md
+++ b/themes/red-snapper/README.md
@@ -10,7 +10,7 @@
 ##><}}*> GIT STATUS
 ### Untracked changes
 Your pet will detect if you added files, but didn't track them. He will open his mouth, hungry of yummy commits!
-![fish shell untracked changes](https://raw.githubusercontent.com/ZuraGuerra/theme-red-snapper/master/hungry.png)
+![fish shell untracked changes](https://raw.githubusercontent.com/ZuraGuerra/theme-red-snapper/master/hungry2.png)
 
 After you commit, he will close his mouth, satiated.
 ![fish shell commited](https://raw.githubusercontent.com/ZuraGuerra/theme-red-snapper/master/fed.png)

--- a/themes/red-snapper/README.md
+++ b/themes/red-snapper/README.md
@@ -1,0 +1,21 @@
+# RED SNAPPER
+![Red Snapper](https://raw.githubusercontent.com/ZuraGuerra/theme-red-snapper/master/redsnapper.jpg)
+
+##><}}*> F E A T U R E S
++ Directory path
++ Git branch name
++ Git status
++ YOUR OWN PET FISH!
+
+##><}}*> GIT STATUS
+### Untracked changes
+Your pet will detect if you added files, but didn't track them. He will open his mouth, hungry of yummy commits!
+![fish shell untracked changes](https://raw.githubusercontent.com/ZuraGuerra/theme-red-snapper/master/hungry.png)
+
+After you commit, he will close his mouth, satiated.
+![fish shell commited](https://raw.githubusercontent.com/ZuraGuerra/theme-red-snapper/master/fed.png)
+
+### Can't find .git
+Something is fishy here! If you are not inside a Git working directory, your pet will go to sleep.
+![fish shell not using git](https://raw.githubusercontent.com/ZuraGuerra/theme-red-snapper/master/fishy.png)
+

--- a/themes/red-snapper/fish_prompt.fish
+++ b/themes/red-snapper/fish_prompt.fish
@@ -1,0 +1,55 @@
+function _git_branch_name
+  echo (command git symbolic-ref HEAD ^/dev/null | sed -e 's|^refs/heads/||')
+end
+
+function _is_git_dirty
+  echo (command git status -s --ignore-submodules=dirty ^/dev/null)
+end
+
+
+function fish_prompt
+  set -l blue (set_color -o blue)
+  set -l green (set_color -o green)
+  set -l red (set_color -o red)
+  set -l yellow (set_color -o yellow)
+
+  set -l orange_fish (set_color -o FFA500)
+  set -l yellow_fish (set_color -o FFB732)
+  set -l red_fish (set_color -o FF725A)
+  set -l black_fish (set_color -o 3F3F3F)
+
+  set_color $fish_color_cwd
+
+  if [ -n "$SSH_CONNECTION" ]
+    printf '%s | ' (hostname | head -c 10)
+  end
+
+  if [ "$HOME" = (pwd) ]
+    printf "$red~"
+  else
+    printf (pwd)
+  end
+
+  printf "$blue ─> "
+  
+
+  if [ (_git_branch_name) ]
+
+    if test (_git_branch_name) = "master"
+      printf "$red(MASTER)"
+    else
+      printf "$red("(_git_branch_name)")"
+    end
+
+    if [ (_is_git_dirty) ]
+      printf " $orange_fish><$yellow_fish}}$black_fish*$red_fish< "
+    else
+      printf " $orange_fish><$yellow_fish}}$black_fish*$orange_fish> "
+    end
+
+  else
+    printf "$blue><}}*> "
+
+  end
+
+end


### PR DESCRIPTION
I added a theme with Git support and an ASCII fish.
https://github.com/ZuraGuerra/theme-red-snapper
![fish shell commited](https://raw.githubusercontent.com/ZuraGuerra/theme-red-snapper/master/fed.png)