### PR TITLE
fixes #496 Do not throw warnings when theme is not set

### DIFF
--- a/plugins/omf/omf.packages.fish
+++ b/plugins/omf/omf.packages.fish
@@ -42,11 +42,15 @@ function omf.packages --argument-names options -d 'Manage all plugins and themes
       end
     case '--list'
       omf.log yellow 'Plugins: '
-      omf.log normal $fish_plugins
+      if test -n "$fish_plugins"
+        omf.log normal $fish_plugins
+      end
 
       omf.log normal ''
       omf.log yellow 'Theme: '
-      omf.log normal $fish_theme
+      if test -n "$fish_theme"
+        omf.log normal $fish_theme
+      end
     case '*'
       omf.log red 'Unknown option'
   end


### PR DESCRIPTION
Check for existence of $fish_plugins and $fish_theme when using the "omf list" feature. This prevents errors/warnings from being displayed when they are not necessary in this case.