### PR TITLE
Add omf commands for listing available plugins/themes and for downloading a plugin/theme

### DIFF
--- a/plugins/omf/omf.fish
+++ b/plugins/omf/omf.fish
@@ -8,11 +8,7 @@ function omf -d "Oh My Fish helper"
   if test (count $argv) -gt 0
     switch $argv[1]
       case 'install'
-        if test (count $argv) -gt 2
-          omf.packages --install $argv[2] $argv[3]
-        else
-          omf.packages --install
-        end
+        omf.packages --install
       case 'update'
         omf.packages --update
       case 'list' 'ls'

--- a/plugins/omf/omf.fish
+++ b/plugins/omf/omf.fish
@@ -8,7 +8,11 @@ function omf -d "Oh My Fish helper"
   if test (count $argv) -gt 0
     switch $argv[1]
       case 'install'
-        omf.packages --install
+        if test (count $argv) -gt 2
+          omf.packages --install $argv[2] $argv[3]
+        else
+          omf.packages --install
+        end
       case 'update'
         omf.packages --update
       case 'list' 'ls'
@@ -19,14 +23,10 @@ function omf -d "Oh My Fish helper"
         if [ $status -eq 0 ]
           omf.log 'green' 'Oh My Fish has been successfully updated.'
         end
-      case 'available-plugins'
-        omf.packages --available-plugins
-      case 'available-themes'
-        omf.packages --available-themes
-      case 'download-plugin'
-        omf.packages --download-plugin $argv[2]
-      case 'download-theme'
-        omf.packages --download-theme $argv[2]
+      case 'plugins'
+        omf.packages --plugins
+      case 'themes'
+        omf.packages --themes
       case '*'
         omf.helper
     end

--- a/plugins/omf/omf.fish
+++ b/plugins/omf/omf.fish
@@ -19,6 +19,14 @@ function omf -d "Oh My Fish helper"
         if [ $status -eq 0 ]
           omf.log 'green' 'Oh My Fish has been successfully updated.'
         end
+      case 'available-plugins'
+        omf.packages --available-plugins
+      case 'available-themes'
+        omf.packages --available-themes
+      case 'download-plugin'
+        omf.packages --download-plugin $argv[2]
+      case 'download-theme'
+        omf.packages --download-theme $argv[2]
       case '*'
         omf.helper
     end

--- a/plugins/omf/omf.helper.fish
+++ b/plugins/omf/omf.helper.fish
@@ -10,12 +10,9 @@ function omf.helper -d 'Prints all functions supported by Oh My Fish helper'
   omf.log normal ''
   omf.log normal '  Examples:'
   omf.log normal '    omf install'
+  omf.log normal '    omf install --plugin|--theme NAME'
   omf.log normal '    omf update'
   omf.log normal '    omf list'
   omf.log normal '    omf self-update'
-  omf.log normal '    omf available-plugins'
-  omf.log normal '    omf available-themes'
-  omf.log normal '    omf download-plugin'
-  omf.log normal '    omf download-theme'
 end
 

--- a/plugins/omf/omf.helper.fish
+++ b/plugins/omf/omf.helper.fish
@@ -10,11 +10,9 @@ function omf.helper -d 'Prints all functions supported by Oh My Fish helper'
   omf.log normal ''
   omf.log normal '  Examples:'
   omf.log normal '    omf install'
-  omf.log normal '    omf install --plugin|--theme NAME'
   omf.log normal '    omf update'
   omf.log normal '    omf list'
   omf.log normal '    omf self-update'
   omf.log normal '    omf plugins'
   omf.log normal '    omf themes'
 end
-

--- a/plugins/omf/omf.helper.fish
+++ b/plugins/omf/omf.helper.fish
@@ -13,5 +13,9 @@ function omf.helper -d 'Prints all functions supported by Oh My Fish helper'
   omf.log normal '    omf update'
   omf.log normal '    omf list'
   omf.log normal '    omf self-update'
+  omf.log normal '    omf available-plugins'
+  omf.log normal '    omf available-themes'
+  omf.log normal '    omf download-plugin'
+  omf.log normal '    omf download-theme'
 end
 

--- a/plugins/omf/omf.helper.fish
+++ b/plugins/omf/omf.helper.fish
@@ -14,5 +14,7 @@ function omf.helper -d 'Prints all functions supported by Oh My Fish helper'
   omf.log normal '    omf update'
   omf.log normal '    omf list'
   omf.log normal '    omf self-update'
+  omf.log normal '    omf plugins'
+  omf.log normal '    omf themes'
 end
 

--- a/plugins/omf/omf.packages.fish
+++ b/plugins/omf/omf.packages.fish
@@ -65,9 +65,9 @@ function omf.packages --argument-names options arg1 arg2 -d 'Manage all plugins 
         omf.log normal $fish_theme
       end
     case '--plugins'
-      omf.remote --plugins | paste -sd ' ' -
+      omf.remote --plugins
     case '--themes'
-      omf.remote --themes  | paste -sd ' ' -
+      omf.remote --themes
     case '*'
       omf.log red 'Unknown option'
   end

--- a/plugins/omf/omf.packages.fish
+++ b/plugins/omf/omf.packages.fish
@@ -11,12 +11,20 @@
 #     Update all packages
 #   --list
 #     List all active packages
+#   --available-plugins
+#     List all plugins available from the oh-my-fish Github repository
+#   --available-themes
+#     List all themes available from the oh-my-fish Github repository
+#   --download-plugin [PLUGIN]
+#     Download and install PLUGIN
+#   --download-theme [THEME]
+#     Download and install THEME
 #
 # DESCRIPTION
 #   Manage all plugins and themes specified on the $fish_plugins
 #   and $fish_theme variables
 #
-function omf.packages --argument-names options -d 'Manage all plugins and themes'
+function omf.packages --argument-names options arg -d 'Manage all plugins and themes'
   set -g __omf_packages_modified 0
 
   switch $options
@@ -51,8 +59,30 @@ function omf.packages --argument-names options -d 'Manage all plugins and themes
       if test -n "$fish_theme"
         omf.log normal $fish_theme
       end
+    case '--available-plugins'
+      get_all_repos | grep "plugin-" | cut -d "-" -f 2- | sort | paste -sd ' ' -
+    case '--available-themes'
+      get_all_repos | grep "theme-"  | cut -d "-" -f 2- | sort | paste -sd ' ' -
+    case '--download-plugin'
+      omf.packages.install --plugin $arg
+    case '--download-theme'
+      omf.packages.install --theme $arg
     case '*'
       omf.log red 'Unknown option'
+  end
+end
+
+function get_all_repos
+  set url "https://api.github.com/orgs/oh-my-fish/repos"
+  set page_count (curl -sI "$url?page=1&per_page=100" | sed -nr 's/^Link:.*page=([0-9]+)&per_page=100>; rel="last".*/\1/p')
+
+  if echo $page_count | grep -vE '^[0-9]+$'
+    echo "Could not access Github API" >&2
+    exit 1
+  end
+
+  for i in (seq $page_count)
+    curl -s "$url?page=$i&per_page=100" | grep \"name\" | tr \": " " | awk '{print $2}'
   end
 end
 

--- a/plugins/omf/omf.remote.fish
+++ b/plugins/omf/omf.remote.fish
@@ -15,7 +15,7 @@
 #
 function omf.remote --argument-names options -d 'List remote plugins and themes'
   set url "https://api.github.com/orgs/oh-my-fish/repos"
-  set page_count (curl -sI "$url?page=1&per_page=100" | sed -nr 's/^Link:.*page=([0-9]+)&per_page=100>; rel="last".*/\1/p')
+  set page_count (curl -sI "$url?page=1&per_page=100" | grep "^Link" | sed 's/Link:.*page=\([0-9]*\)&per_page=100>; rel="last".*/\1/')
 
   if echo $page_count | grep -vE '^[0-9]+$'
     echo "Could not access Github API" >&2

--- a/plugins/omf/omf.remote.fish
+++ b/plugins/omf/omf.remote.fish
@@ -1,0 +1,39 @@
+# NAME
+#   omf.remote - List remote plugins and themes
+#
+# SYNOPSIS
+#   omf.remote [OPTIONS]
+#
+# OPTIONS
+#   --plugins
+#     List all available plugins
+#   --themes
+#     List all available themes
+#
+# DESCRIPTION
+#   List remote plugins and themes from the oh-my-fish Github repository
+#
+function omf.remote --argument-names options -d 'List remote plugins and themes'
+  set url "https://api.github.com/orgs/oh-my-fish/repos"
+  set page_count (curl -sI "$url?page=1&per_page=100" | sed -nr 's/^Link:.*page=([0-9]+)&per_page=100>; rel="last".*/\1/p')
+
+  if echo $page_count | grep -vE '^[0-9]+$'
+    echo "Could not access Github API" >&2
+    exit 1
+  end
+
+  set repos ""
+  for i in (seq $page_count)
+    set answer (curl -s "$url?page=$i&per_page=100" | grep \"name\" | tr \": " " | awk '{print $2}')
+    set repos "$answer $repos"
+  end
+
+  switch $options
+    case '--plugins'
+      echo $repos | tr ' ' "\\n" | grep "plugin-" | cut -d "-" -f 2- | sort | paste -sd " " -
+    case '--themes'
+      echo $repos | tr ' ' "\\n" | grep "theme-"  | cut -d "-" -f 2- | sort | paste -sd " " -
+    case '*'
+      omf.log red 'Unknown option'
+  end
+end


### PR DESCRIPTION
It would be nice to have a possibility to download themes and plugins from the oh-my-fish repository and to list all available ones.

This is a proposal how it could be done. It adds the following commands to omf:
* available-plugins (shows all plugins from github repository)
* available-themes (shows all themes from github repository)
* download-plugin PLUGIN (uses omf.packages.install to download and install a plugin from the github repo)
* download-theme THEME (uses omf.packages.install to download and install a theme from the github repo)

This is not only for human use: e.g. the new "omf.packages --download-theme" could be used by the "theme" plugin to automatically download a theme when it's not locally available (without duplicating code but with the nice "Installing..." message).

I'm not fixed on the naming or on how things work and I'd be happy about feedback. Also I'm not a fish expert, so I'm not quite sure if the coding style meets the usual conventions.