### PR TITLE
Remove pkg-/theme- from folder name

### DIFF
--- a/pkg/omf/cli/omf.install.fish
+++ b/pkg/omf/cli/omf.install.fish
@@ -36,7 +36,7 @@ function omf.install -a type_flag name_or_url
   if test -e $OMF_PATH/db/$parent_path/$name_or_url
     set target $parent_path/$name_or_url
   else
-    set -l local_name (basename $name_or_url)
+    set -l local_name (basename $name_or_url | sed "s/^pkg-//;s/^plugin-//;s/^theme-//")
     if test -e $OMF_PATH/$parent_path/$local_name
       echo (omf::err)"Error: $local_name $install_type already installed."(omf::off) 1^&2
     else


### PR DESCRIPTION
When installing packages (plugins) or themes using a URL, we should
strip the plugin-/pkg-/theme- from the repository name if it exists.