### PR TITLE
Add apt plugin to db

### DIFF
--- a/db/pkg/apt
+++ b/db/pkg/apt
@@ -1,0 +1,1 @@
+https://github.com/coderstephen/plugin-apt


### PR DESCRIPTION
This adds [my apt plugin](https://github.com/coderstephen/plugin-apt) to the general package database. This is a package that I've developed and tweaked over the years that started out as a bash script. When I switched to Fish a few years ago, this script was rewritten in Fish and became a function, which became an OMF plugin when I started using the framework several months ago.

I originally kept the package inside my personal dotfiles repo, but I figured that other Debian or Ubuntu users might benefit from the package as well.

Thoughts on the package?