### PR TITLE
bundle: move related functions to omf.bundle namespace

### DIFF
--- a/pkg/omf/cli/omf.bundle.add.fish
+++ b/pkg/omf/cli/omf.bundle.add.fish
@@ -1,4 +1,4 @@
-function omf.persist -a type name_or_url
+function omf.bundle.add -a type name_or_url
   function __omf.write_bundle
     set -l bundle $OMF_CONFIG/bundle
     set -l record $argv

--- a/pkg/omf/cli/omf.bundle.install.fish
+++ b/pkg/omf/cli/omf.bundle.install.fish
@@ -1,21 +1,22 @@
-function omf.install_bundle
+function omf.bundle.install
 
   if test -f $OMF_CONFIG/bundle
     set packages (omf.list_local_packages)
     set themes (omf.list_installed_themes)
 
-    for record in (cat $OMF_CONFIG/bundle)
+    for record in (cat $OMF_CONFIG/bundle | uniq)
       set type (echo $record | cut -d' ' -f1)
-      set name (echo $record | cut -d' ' -f2- | sed -e 's/\.git//')
+      set name_or_url (echo $record | cut -d' ' -f2-)
+      set name (basename $name_or_url | sed 's/\.git//;s/^pkg-//;s/^plugin-//;s/^theme-//')
 
       switch $type
       case "package"
-        if not contains (basename $name) $packages
+        if not contains $name $packages
           omf.install --pkg $name
         end
 
       case "theme"
-        if not contains (basename $name) $themes
+        if not contains $name $themes
           omf.install --theme $name
         end
       end

--- a/pkg/omf/cli/omf.bundle.remove.fish
+++ b/pkg/omf/cli/omf.bundle.remove.fish
@@ -1,0 +1,23 @@
+function omf.bundle.remove
+    set bundle $OMF_CONFIG/bundle
+
+    if test -f $bundle
+      set type $argv[1]
+      set name $argv[2]
+      set bundle_contents (cat $bundle | uniq)
+
+      rm -f $bundle
+
+      for record in $bundle_contents
+        set record_type (echo $record | cut -d' ' -f1)
+        set record_name (echo $record | cut -d' ' -f2-)
+        set record_basename (basename (echo $record_name | \
+          sed -e 's/\.git$//') | sed 's/^pkg-//;s/^plugin-//;s/^theme-//')
+
+        if not test "$type" = "$record_type" -a "$name" = "$record_basename"
+          echo "$record_type $record_name" >> $bundle
+        end
+
+      end
+    end
+  end

--- a/pkg/omf/cli/omf.install.fish
+++ b/pkg/omf/cli/omf.install.fish
@@ -29,7 +29,7 @@ function omf.install -a type_flag name_or_url
     else
       echo (omf::dim)"Trying to clone from URL..."(omf::off)
       if omf.repo.clone $name_or_url $OMF_PATH/$parent_path/$local_name
-        omf.persist $install_type $name_or_url
+        omf.bundle.add $install_type $name_or_url
         _display_success "$install_type $name_or_url"
       else
         _display_error "$install_type $name_or_url"
@@ -47,7 +47,7 @@ function omf.install -a type_flag name_or_url
   else
     echo (omf::dim)"Installing $name_or_url $install_type..."(omf::off)
     if omf.repo.clone (cat $OMF_PATH/db/$target) $OMF_PATH/$target
-      omf.persist $install_type $name_or_url
+      omf.bundle.add $install_type $name_or_url
       _display_success "$install_type $name_or_url"
     else
       _display_error "$install_type $name_or_url"

--- a/pkg/omf/cli/omf.remove_package.fish
+++ b/pkg/omf/cli/omf.remove_package.fish
@@ -1,28 +1,5 @@
 function omf.remove_package
 
-  function _remove_from_bundle
-    set bundle $OMF_CONFIG/bundle
-
-    if test -f $bundle
-      set type $argv[1]
-      set name $argv[2]
-      set bundle_contents (cat $bundle)
-
-      rm -f $bundle
-
-      for record in $bundle_contents
-        set record_type (echo $record | cut -d' ' -f1)
-        set record_name (echo $record | cut -d' ' -f2-)
-        set record_basename (basename (echo $record_name | sed -e 's/\.git$//'))
-
-        if not test "$type" = "$record_type" -a "$name" = "$record_basename"
-          echo "$record_type $record_name" >> $bundle
-        end
-
-      end
-    end
-  end
-
   for pkg in $argv
     set -l remove_status 1
 
@@ -39,7 +16,7 @@ function omf.remove_package
       not test -d $path; and continue
 
       emit uninstall_$pkg
-      _remove_from_bundle "package" $pkg
+      omf.bundle.remove "package" $pkg
 
       rm -rf $path
       set remove_status $status
@@ -52,7 +29,7 @@ function omf.remove_package
         echo default > $OMF_CONFIG/theme
       end
 
-      _remove_from_bundle "theme" $pkg
+      omf.bundle.remove "theme" $pkg
 
       rm -rf $path
       set remove_status $status

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -89,7 +89,7 @@ function omf -d "Oh My Fish"
 
     case "i" "install" "get"
       if test (count $argv) -eq 1
-        omf.install_bundle
+        omf.bundle.install
       else
         omf.install_package $argv[2..-1]
         refresh


### PR DESCRIPTION
Improving the work done in #15, this PR moves bundle related functions to `omf.bundle` namespace, splitting them in its own files. I think this is necessary to make the code cleaner and more maintainable.

This PR also fixes #22 and include work done on PR #21 as a batch. Thanks @scorphus :)