### PR TITLE
Fixes on omf destroy and omf.remove_package

### DIFF
--- a/pkg/omf/cli/omf.destroy.fish
+++ b/pkg/omf/cli/omf.destroy.fish
@@ -1,7 +1,9 @@
 function omf.destroy -d "Remove Oh My Fish"
   echo (omf::dim)"Removing Oh My Fish..."(omf::off)
 
-  omf.remove_package (basename $OMF_PATH/pkg/*) >/dev/null ^&1
+  for pkg in (basename $OMF_PATH/pkg/*)
+    omf.remove_package $pkg >/dev/null ^&1
+  end
 
   if test -e "$HOME/.config/fish/config.copy"
     mv "$HOME/.config/fish/config".{copy,fish}

--- a/pkg/omf/cli/omf.destroy.fish
+++ b/pkg/omf/cli/omf.destroy.fish
@@ -5,8 +5,15 @@ function omf.destroy -d "Remove Oh My Fish"
     omf.remove_package $pkg >/dev/null ^&1
   end
 
-  if test -e "$HOME/.config/fish/config.copy"
-    mv "$HOME/.config/fish/config".{copy,fish}
+  set -l fish_config $XDG_CONFIG_HOME/fish
+  if test "$fish_config" = "/fish"
+    set fish_config $HOME/.config/fish
+  end
+
+  set -l localbackup (find $fish_config -regextype posix-extended -regex '^.*fish/config\.[[:digit:]]+\.copy$' |\
+    sort -r |head -1)
+  if test -n $localbackup
+    mv $localbackup "$fish_config/config.fish"
   end
 
   if test "$OMF_PATH" != "$HOME"

--- a/pkg/omf/cli/omf.remove_package.fish
+++ b/pkg/omf/cli/omf.remove_package.fish
@@ -1,45 +1,44 @@
 function omf.remove_package
 
-  for pkg in $argv
-    set -l remove_status 1
+  set -l pkg $argv
+  set -l remove_status 1
 
-    if not omf.util_valid_package $pkg
-      if test $pkg = "omf" -o $pkg = "default"
-        echo (omf::err)"You can't remove `$pkg`"(omf::off) 1^&2
-      else
-        echo (omf::err)"$pkg is not a valid package/theme name"(omf::off) 1^&2
-      end
-      return $OMF_INVALID_ARG
-    end
-
-    for path in {$OMF_PATH,$OMF_CONFIG}/{pkg}/$pkg
-      not test -d $path; and continue
-
-      emit uninstall_$pkg
-      omf.bundle.remove "package" $pkg
-
-      rm -rf $path
-      set remove_status $status
-    end
-
-    for path in {$OMF_PATH,$OMF_CONFIG}/{themes}/$pkg
-      not test -d $path; and continue
-
-      if test $pkg = (cat $OMF_CONFIG/theme)
-        echo default > $OMF_CONFIG/theme
-      end
-
-      omf.bundle.remove "theme" $pkg
-
-      rm -rf $path
-      set remove_status $status
-    end
-
-    if test $remove_status -eq 0
-      echo (omf::em)"$pkg successfully removed."(omf::off)
-      refresh
+  if not omf.util_valid_package $pkg
+    if test $pkg = "omf" -o $pkg = "default"
+      echo (omf::err)"You can't remove `$pkg`"(omf::off) 1^&2
     else
-      echo (omf::err)"$pkg could not be found"(omf::off) 1^&2
+      echo (omf::err)"$pkg is not a valid package/theme name"(omf::off) 1^&2
     end
+    return $OMF_INVALID_ARG
   end
+
+  for path in {$OMF_PATH,$OMF_CONFIG}/{pkg}/$pkg
+    not test -d $path; and continue
+
+    emit uninstall_$pkg
+    omf.bundle.remove "package" $pkg
+
+    rm -rf $path
+    set remove_status $status
+  end
+
+  for path in {$OMF_PATH,$OMF_CONFIG}/{themes}/$pkg
+    not test -d $path; and continue
+
+    if test $pkg = (cat $OMF_CONFIG/theme)
+      echo default > $OMF_CONFIG/theme
+    end
+
+    omf.bundle.remove "theme" $pkg
+
+    rm -rf $path
+    set remove_status $status
+  end
+
+  if test $remove_status -eq 0
+    echo (omf::em)"$pkg successfully removed."(omf::off)
+  else
+    echo (omf::err)"$pkg could not be found"(omf::off) 1^&2
+  end
+  return $remove_status
 end

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -120,7 +120,7 @@ function omf -d "Oh My Fish"
         echo "Usage: $_ "(omf::em)"$argv[1]"(omf::off)" <[package|theme] name>" 1^&2
         return $OMF_INVALID_ARG
       end
-      omf.remove_package $argv[2..-1]
+      omf.remove_package $argv[2] ; and refresh
 
     case "u" "up" "upd" "update"
       pushd $OMF_PATH


### PR DESCRIPTION
**omf.destroy** was broken because of a [premature refresh].
And with [this code] it was giving the impression that omf was hanging while in fact fish was running without a display.

When fixing the bug I assumed that remove_package do the minimal (handle only one pkg)
At the time of the PR the indent in [omf.remove_package.fish] might be broken.

I am now working on [omf.destroy.fish] to find the most recent backup of config.fish (for this PR)


[premature refresh]: https://github.com/oh-my-fish/oh-my-fish/blob/4b0dbc270b9ab73d56aa0d07d820243d22479892/pkg/omf/cli/omf.remove_package.fish#L40
[this code]: https://github.com/oh-my-fish/oh-my-fish/blob/4b0dbc270b9ab73d56aa0d07d820243d22479892/pkg/omf/cli/omf.destroy.fish#L4
[omf.remove_package.fish]: https://github.com/jeremiejig/oh-my-fish/blob/d40328974835112fdcb2a6309c44c57b035a88c9/pkg/omf/cli/omf.remove_package.fish
[omf.destroy.fish]: https://github.com/jeremiejig/oh-my-fish/blob/d40328974835112fdcb2a6309c44c57b035a88c9/pkg/omf/cli/omf.destroy.fish#L8