### PR TITLE
Fix update when the pkg is not in database.

### DIFF
--- a/pkg/omf/cli/omf.install.fish
+++ b/pkg/omf/cli/omf.install.fish
@@ -26,6 +26,7 @@ function omf.install -a type_flag name_or_url
     set -l local_name (basename $name_or_url | sed "s/^pkg-//;s/^plugin-//;s/^theme-//")
     if test -e $OMF_PATH/$parent_path/$local_name
       echo (omf::err)"Error: $local_name $install_type already installed."(omf::off) 1^&2
+      return $OMF_UNKNOWN_ERR
     else
       echo (omf::dim)"Trying to clone from URL..."(omf::off)
       if omf.repo.clone $name_or_url $OMF_PATH/$parent_path/$local_name

--- a/pkg/omf/cli/omf.install.fish
+++ b/pkg/omf/cli/omf.install.fish
@@ -24,7 +24,9 @@ function omf.install -a type_flag name_or_url
     set target $parent_path/$name_or_url
   else
     set -l local_name (basename $name_or_url | sed "s/^pkg-//;s/^plugin-//;s/^theme-//")
-    if test -e $OMF_PATH/$parent_path/$local_name
+    if test "$local_name" = "$name_or_url"
+      set target $parent_path/$name_or_url
+    else if test -e $OMF_PATH/$parent_path/$local_name
       echo (omf::err)"Error: $local_name $install_type already installed."(omf::off) 1^&2
       return $OMF_UNKNOWN_ERR
     else
@@ -32,11 +34,11 @@ function omf.install -a type_flag name_or_url
       if omf.repo.clone $name_or_url $OMF_PATH/$parent_path/$local_name
         omf.bundle.add $install_type $name_or_url
         _display_success "$install_type $name_or_url"
+    	return 0
       else
         _display_error "$install_type $name_or_url"
       end
     end
-    return 0
   end
 
   if test -e $OMF_PATH/$target

--- a/pkg/omf/cli/omf.install_package.fish
+++ b/pkg/omf/cli/omf.install_package.fish
@@ -1,10 +1,10 @@
 function omf.install_package -d "Return success for at least one successful install."
-  set -l return_code 1
+  set -l return_code $OMF_UNKNOWN_ERR
   for search in $argv
     omf.install --pkg $search
-    set -l code $status
-    if test $code -eq 0
-      set return_code $code
+    set -l install_code $status
+    if test $install_code -eq 0
+      set return_code $install_code
     end
   end
   return $return_code

--- a/pkg/omf/cli/omf.install_package.fish
+++ b/pkg/omf/cli/omf.install_package.fish
@@ -1,4 +1,5 @@
-function omf.install_package -d "Return success for at least one successful install."
+# Return success for at least one successful install.
+function omf.install_package 
   set -l return_code $OMF_UNKNOWN_ERR
   for search in $argv
     omf.install --pkg $search

--- a/pkg/omf/cli/omf.install_package.fish
+++ b/pkg/omf/cli/omf.install_package.fish
@@ -1,5 +1,11 @@
-function omf.install_package
+function omf.install_package -d "Return success for at least one successful install."
+  set -l return_code 1
   for search in $argv
     omf.install --pkg $search
+    set -l code $status
+    if test $code -eq 0
+      set return_code $code
+    end
   end
+  return $return_code
 end

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -91,8 +91,9 @@ function omf -d "Oh My Fish"
       if test (count $argv) -eq 1
         omf.bundle.install
       else
-        omf.install_package $argv[2..-1]
-        refresh
+        if omf.install_package $argv[2..-1]
+          refresh
+        end
       end
 
     case "t" "theme"


### PR DESCRIPTION
I change some behavior to avoid reloading when no installation has been done.

I also add a check so that pkg add by url (not present in `$OMF_PATH/db/pkg/`) will now update.

I previously add this behaviour when doing a `omf update`

```console
Updating Oh My Fish...
Oh My Fish is up to date.
Updating bobthefish theme...
✔ bobthefish theme up to date.
Updating apt package...
✔ apt package up to date.
Updating bundler package...
✔ bundler package up to date.
Updating extract package...
✔ extract package up to date.
Error: mc package already installed.
```