### PR TITLE
Migrate old config format to bundle

### DIFF
--- a/pkg/omf/cli/omf.bundle.install.fish
+++ b/pkg/omf/cli/omf.bundle.install.fish
@@ -1,5 +1,7 @@
 function omf.bundle.install
 
+  omf.util.migrate_old_bundle
+
   if test -f $OMF_CONFIG/bundle
     set packages (omf.list_local_packages)
     set themes (omf.list_installed_themes)

--- a/pkg/omf/util/omf.util.migrate_old_bundle.fish
+++ b/pkg/omf/util/omf.util.migrate_old_bundle.fish
@@ -1,0 +1,22 @@
+function omf.util.migrate_old_bundle
+  set OMF_OLD_CONFIG ~/.config/fish/config.fish
+  set OLD_PLUGIN (grep "Plugin" $OMF_OLD_CONFIG 2> /dev/null)
+  set OLD_THEMES (grep "Theme" $OMF_OLD_CONFIG 2> /dev/null)
+  set BUNDLE_PATH $OMF_CONFIG/bundle
+
+  if test -z "$OLD_PLUGIN" -a -z "$OLD_THEMES"
+    return 0
+  end
+
+  for theme in $OLD_THEMES
+    omf.bundle.add theme (echo $theme | sed -n 's/Theme "\(.*\)"/\1/p')
+  end
+
+  for plugin in $OLD_PLUGIN
+    omf.bundle.add package (echo $plugin | sed -n 's/Plugin "\(.*\)"/\1/p')
+  end
+
+  sed -i '/Theme.*/d;/Plugin.*/d' $OMF_OLD_CONFIG
+
+  return 0
+end


### PR DESCRIPTION
This PR makes `omf install` without parameters always check old config `~/.config/fish/config.fish` and migrate `Plugin` and `Theme` entries to new bundle format. It's not the perfect approach to the matter, but it works as a palliative for the time being.