### PR TITLE
Remove src attribute from spacer image in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <img src="docs/logo.png" align="left" width="192px" height="192px"/>
-<img src="" align="left" width="0" height="192px" hspace="10"/>
+<img align="left" width="0" height="192px" hspace="10"/>
 
 > The <a href="http://fishshell.com">Fishshell</a> Framework
 


### PR DESCRIPTION
Spacer still works just as good.

This will make Chrome and its siblings not display a broken image placeholder
in the spacer.

Confirmed OK on Firefox and Safari.

<img width="882" alt="screen shot 2015-09-26 at 7 52 58 pm" src="https://cloud.githubusercontent.com/assets/5363/10121002/abb0072e-648c-11e5-83af-b24148b3b83e.png">

