### PR TITLE
Add test-generate-themes-doc.fish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script: pwd; tree -h
 script:
   - /bin/sh tools/travis_install_omf.sh
   - tests/test_runner.fish
+  - tests/test-generate-themes-doc.fish
 
 after_script:
   - cd ~/.config/fish; tree -h; find . -type f | xargs cat

--- a/docs/Themes.md
+++ b/docs/Themes.md
@@ -34,6 +34,7 @@
 - [led](#led)
 - [mtahmed](#mtahmed)
 - [nai](#nai)
+- [nelsonjchen](#nelsonjchen)
 - [numist](#numist)
 - [ocean](#ocean)
 - [perryh](#perryh)
@@ -1201,7 +1202,7 @@ theme](http://jacaetevha.github.io/oh-my-fish/screenshot.png)
 # krisleech
 #### krisleech
 
-A very simple ZSH theme optimized for Git. Less is more.
+A very simple theme optimized for Git. Less is more.
 
 ![krisleech theme](https://f.cloud.github.com/assets/66143/930316/732ea576-0008-11e3-964c-98410709d00c.png)
 
@@ -1336,6 +1337,58 @@ A minimalist fish theme which displays git branch and status information.
 
 * Truncated CWD (just the current folder name)
 * Git branch and dirty state (if applicable)
+
+
+# nelsonjchen
+<div align="center">
+  <a href="http://github.com/oh-my-fish/oh-my-fish">
+  <img width=90px  src="https://cloud.githubusercontent.com/assets/8317250/8510172/f006f0a4-230f-11e5-98b6-5c2e3c87088f.png">
+  </a>
+</div>
+<br>
+
+> nelsonjchen theme for [Oh My Fish][omf-link]. Based on re5et in Oh-My-Zsh.
+
+#### Install
+
+```fish
+$ omf u nelsonjchen
+```
+
+#### Features and Differences
+
+* Pretty colors
+* Two line prompt
+* Git Prompt using off-the-shelf fish functions
+  * Note that the symbology, colors, and features are more than the `zsh` version and they don't match up 1-to-1. For example, checking out a tag will show the tag name in `fish` but the re5et version in `zsh` will simply show the commit ID. This was one such freebie amongst many I just left in while porting since the `fish` script was giving it to me for free anyway. It is still pretty close though.
+* Red user prompt if `root`
+* 12 hour clock
+  * re5et: 24 hour clock
+* MM DD YY date format
+  * re5et: YY MM DD date format
+  
+#### Omissions from the re5et version
+
+* Trimming down the working directory display only works on `~`. The original re5et prompt would also trim based on the current environment variables set. For example, if you had the environment variable `FOO` set to `/usr/local` and you did `cd /usr/local`, you would see `$FOO/` in the prompt as the current working directory. I'm not sure how I would get this working. `fish` does appear to have a condensation function but it goes beyond simple environment variable replacement and I can't figure out how to turn it off.
+
+#### Screenshot
+
+<p align="center">
+<img src="nelsonjchen.png">
+</p>
+
+### License
+
+[MIT][mit] © [Nelson Chen][author] et [al][contributors]
+
+
+[mit]:            http://opensource.org/licenses/MIT
+[author]:         http://github.com/nelsonjchen
+[contributors]:   https://github.com/nelsonjchen/omf-theme-nelsonjchen/graphs/contributors
+[omf-link]:       https://www.github.com/oh-my-fish/oh-my-fish
+
+[license-badge]:  https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square
+[travis-badge]:   http://img.shields.io/travis/nelsonjchen/omf-theme-nelsonjchen.svg?style=flat-square
 
 
 # numist

--- a/tests/test-generate-themes-doc.fish
+++ b/tests/test-generate-themes-doc.fish
@@ -1,0 +1,28 @@
+#!/usr/bin/env fish
+
+function __test_themes_doc
+  set -l project_dir (status -f|xargs dirname|xargs dirname)
+  set -l theme_output (mktemp /tmp/fish.test.Themes.XXXXX.md)
+  set -l theme_doc $project_dir/docs/Themes.md
+
+  fish $project_dir/tools/generate-themes-doc.fish $theme_output
+
+  if cmp -s $theme_doc $theme_output
+    echo "OK: $theme_doc is up-to-date"
+    exit 0
+  else
+    diff $theme_doc $theme_output
+    echo "WARN: $theme_doc is not up-to-date"
+    exit 1
+  end
+end
+
+set -l compare_url "https://api.github.com/repos/$TRAVIS_REPO_SLUG/compare/$TRAVIS_COMMIT_RANGE"
+echo "Detecting changes: $compare_url ..."
+if curl -s $compare_url | grep -E '"filename": ?"db/themes'
+  echo "Changes to themes found. Verifying Themes.doc ..."
+  __test_themes_doc
+else
+  echo "OK: No changes to themes found."
+  exit 0
+end

--- a/tools/generate-themes-doc.fish
+++ b/tools/generate-themes-doc.fish
@@ -1,7 +1,11 @@
 #!/usr/bin/env fish
 
 set -l project_dir (status -f|xargs dirname|xargs dirname)
-set -l theme_doc "$project_dir/docs/Themes.md"
+if [ $argv ]
+  set theme_doc $argv
+else
+  set theme_doc "$project_dir/docs/Themes.md"
+end
 set temp_theme_contents (mktemp /tmp/fish.Themes.Content.XXXXX.md)
 set temp_theme_toc (mktemp /tmp/fish.Themes.TOC.XXXXX.md)
 
@@ -25,7 +29,7 @@ function __find_readme -a raw_content
   end
 end
 
-echo "Generating Themes documentation ..."
+echo "Generating Themes documentation to $theme_doc ..."
 echo "# Available themes" > $temp_theme_toc
 
 for theme in (command find $project_dir/db/themes/ -type f|sort)
@@ -47,7 +51,7 @@ end
 
 echo "" >> $temp_theme_toc
 cat $temp_theme_contents >> $temp_theme_toc
-rm $theme_doc
+rm -f $theme_doc
 cat $temp_theme_toc >> $theme_doc
 echo "All done: $theme_doc"
 


### PR DESCRIPTION
* Run with Travis CI
* Fail build if `docs/Themes.md` is no longer up-to-date

Here's Travis examples:
* [Build fails](https://travis-ci.org/Pyppe/oh-my-fish/builds/82439638)
* [Build succeeds](https://travis-ci.org/Pyppe/oh-my-fish/builds/82439947)

The iffy thing here is that whenever any theme README gets updated, the Travis-build will fail... Any thoughts?