### PR TITLE
Split custom "init.fish" into clearer "before.init.fish" and "init.fish"

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,18 +101,21 @@ Oh My Fish installer places its startup code in your fish config file (`~/.confi
 
 ## Startup
 
-Everytime you open a new shell the startup code initializes Oh My Fish installation path and the _config_ path (`~/.config/omf` by default), sourcing the [`init.fish`](init.fish) script afterwards, which autoload packages, themes and your custom init file. For more information check the [FAQ](docs/FAQ.md#what-does-oh-my-fish-do-exactly).
+Everytime you open a new shell the startup code initializes Oh My Fish installation path and the _config_ path (`~/.config/omf` by default), sourcing the [`init.fish`](init.fish) script afterwards, which autoload packages, themes and your custom init files. For more information check the [FAQ](docs/FAQ.md#what-does-oh-my-fish-do-exactly).
 
 ## Dotfiles
 
 The `$OMF_CONFIG` directory represents the user state of Oh My Fish, and is the perfect
-candidate for being added to your dotfiles and/or checked out to version control. There are three important files:
+candidate for being added to your dotfiles and/or checked out to version control. There are four important files:
 
 - __`theme`__ - The current theme
 - __`bundle`__ - List of currently installed packages/themes
-- __`init.fish`__ - Custom script sourced at shell start
+- __`init.fish`__ - Custom script sourced after shell start
+- __`before.init.fish`__ - Custom script sourced before shell start
 
 It's highly recommended that your custom startup commands go into `init.fish` file instead of `~/.config/fish/config.fish`, as this allows you to keep the whole `$OMF_CONFIG` directory under version control.
+
+If you need startup commands to be run *before* Oh My Fish begins loading plugins, place them in `before.init.fish` instead. If you're unsure, it is usually best to put things in `init.fish`.
 
 ### About the bundle
 

--- a/docs/en-US/FAQ.md
+++ b/docs/en-US/FAQ.md
@@ -45,6 +45,8 @@ There are roughly 3 kinds of packages:
 
 ## What does Oh My Fish do exactly?
 
++ Run `$OMF_CONFIG/before.init.fish` if available.
+
 + Autoload installed packages and themes under `$OMF_PATH/`.
 
 + Autoload your config path. `~/.config/omf` by default, but configurable via `$OMF_CONFIG`.

--- a/docs/zh-CN/FAQ.md
+++ b/docs/zh-CN/FAQ.md
@@ -44,6 +44,8 @@ Oh My Fish 包是使用 fish 编写的一系列主题和插件用于扩展 Shell
 
 ## Oh My Fish 主要都干了什么?
 
++ 如果存在 `$OMF_CONFIG/before.init.fish`。
+
 + 自动加载 `$OMF_PATH/` 目录下已安装的插件和主题。
 
 + 自动加载你的配置。默认路径 `~/.config/omf`，除非你自定义了 `$OMF_CONFIG` 变量。

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -92,10 +92,16 @@ Oh My Fish 安装脚本会把自身启动代码加载到 fish 的配置文件 (`
 ## Dotfiles
 
 `$OMF_CONFIG` 目录存储用户使用 Oh My Fish 的重要配置参数，这是最完美的方式把该目录的所有文件加入你的 dotfiles 或加入到版本控制。
-这里有两个重要的文件：
+有四个重要文件：
 
 - __`theme`__ - 当前主题
 - __`bundle`__ - 显示当前已安装的插件/主题列表
+- __`init.fish`__ - 壳开始后执行的自定义脚本
+- __`before.init.fish`__ - 壳开始前执行的自定义脚本
+
+它强烈建议您自定义的启动命令进入 `init.fish` 文件而不是 `~/.config/omf/config.fish`，因为这可以让你保持在版本控制整个 `$OMF_CONFIG` 目录。
+
+如果你需要的Starup命令来运行*之前*噢，我的鱼开始加载插件，将它们放置在 `before.init.fish` 代替。如果你不确定，通常最好把东西 `init.fish` 。
 
 ### 关于 bundle
 

--- a/init.fish
+++ b/init.fish
@@ -2,6 +2,8 @@
 #   Initialize Oh My Fish.
 #
 # OVERVIEW
+#   + Source $OMF_CONFIG/before.init.fish
+#
 #   + Autoload Oh My Fish packages, themes and config path
 #   + For each <pkg> inside {$OMF_PATH,$OMF_CONFIG}
 #     + Autoload <pkg> directory
@@ -31,6 +33,9 @@ if not set -q OMF_CONFIG
   set -q XDG_CONFIG_HOME; or set -l XDG_CONFIG_HOME "$HOME/.config"
   set -gx OMF_CONFIG "$XDG_CONFIG_HOME/omf"
 end
+
+# Source custom before.init.fish file
+source $OMF_CONFIG/before.init.fish ^/dev/null
 
 # Save the head of function path and autoload core functions
 set -l user_function_path $fish_function_path[1]

--- a/templates/config.fish
+++ b/templates/config.fish
@@ -3,8 +3,8 @@ set -g OMF_PATH {{OMF_PATH}}
 
 ### Configuration required to load oh-my-fish ###
 # Note: Only add configurations that are required to be set before oh-my-fish is loaded.
-# For common configurations, we advise you to add them to your $OMF_CONFIG/init.fish file or
-# to create a custom plugin instead.
+# For common configurations, we advise you to add them to your $OMF_CONFIG/init.fish
+# file or to create a custom plugin instead.
 
 # Load oh-my-fish configuration.
 source $OMF_PATH/init.fish


### PR DESCRIPTION
To allow variables to be set before plugins (or Oh My Fish) are loaded, you can place scripts in `$OMF_CONFIG/before.init.fish`. For consistency, `$OMF_CONFIG/init.fish` is now `$OMF_CONFIG/after.init.fish`.

This doesn't currently make considerations for backwards compatibility.