### PR TITLE
Add kill-on-port pkg

### DIFF
--- a/db/pkg/kill-on-port
+++ b/db/pkg/kill-on-port
@@ -1,0 +1,1 @@
+https://github.com/vincentjames501/fish-kill-on-port


### PR DESCRIPTION
Is there a good way of specifying transient dependencies? This pkg requires the getopts pkg for example...?