### PR TITLE
Move $OMF_CONFIG variable to $OMF_PATH/init.fish

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -89,8 +89,7 @@ omf_install() {
   touch ${fish_config_file} >/dev/null 2>&1
   test ! -w ${fish_config_file} && die "Fish configuration file is not writable, aborting."
 
-  sed "s|{{OMF_PATH}}|$(echo "${OMF_PATH}" | sed -e "s|$HOME|\$HOME|")|;\
-       s|{{OMF_CONFIG}}|$(echo "${OMF_CONFIG}" | sed -e "s|$HOME|\$HOME|")|" \
+  sed "s|{{OMF_PATH}}|$(echo "${OMF_PATH}" | sed -e "s|$HOME|\$HOME|")|" \
     "${OMF_PATH}/templates/config.fish" > "${fish_config_file}"
 
   if [ ! -d "${OMF_CONFIG}" ]; then

--- a/init.fish
+++ b/init.fish
@@ -26,6 +26,12 @@ else
   set -gx ORIGINAL_PATH $PATH
 end
 
+# Set OMF_CONFIG if not set.
+if not set -q OMF_CONFIG
+  set -q XDG_CONFIG_HOME; or set -l XDG_CONFIG_HOME "$HOME/.config"
+  set -gx OMF_CONFIG "$XDG_CONFIG_HOME/omf"
+end
+
 # Save the head of function path and autoload core functions
 set -l user_function_path $fish_function_path[1]
 set fish_function_path[1] $OMF_PATH/lib

--- a/templates/config.fish
+++ b/templates/config.fish
@@ -1,9 +1,6 @@
 # Path to your oh-my-fish.
 set -g OMF_PATH {{OMF_PATH}}
 
-# Path to your oh-my-fish configuration.
-set -g OMF_CONFIG {{OMF_CONFIG}}
-
 ### Configuration required to load oh-my-fish ###
 # Note: Only add configurations that are required to be set before oh-my-fish is loaded.
 # For common configurations, we advise you to add them to your $OMF_CONFIG/init.fish file or


### PR DESCRIPTION
This PR sets the default value of `OMF_CONFIG` variable in framework `init.fish` file. The variable can still be overridden by the user by setting it on `~/.config/fish/config.fish file`.

This is in preparation to rewriting install script in plain fish, which will ditch config template and stop replacing `config.fish`contents in favor of just appending Oh My Fish startup.