### PR TITLE
Save history before replacing shell process

### DIFF
--- a/lib/refresh.fish
+++ b/lib/refresh.fish
@@ -4,6 +4,9 @@
 # OVERVIEW
 #   Refresh (reload) the current fish session.
 
-function refresh -d "refresh the fish session"
-  set -q CI; or exec fish < /dev/tty
+function refresh -d "Refresh fish session by replacing current process"
+  if not set -q CI
+    history --save
+    exec fish < /dev/tty
+  end
 end


### PR DESCRIPTION
Fixes an issue with history between shell reloads via refresh function call.
As `exec` replaces the current process in a non-gently fashion, the
persistent history could be out of sync with the in-memory history.

Calling `history --save` before `exec` should force the shell to persist the
history before replacing the current process.