### PR TITLE
Only emit uninstall_* event on `omf destroy`

### DIFF
--- a/pkg/omf/cli/omf.destroy.fish
+++ b/pkg/omf/cli/omf.destroy.fish
@@ -2,7 +2,7 @@ function omf.destroy -d "Remove Oh My Fish"
   echo (omf::dim)"Removing Oh My Fish..."(omf::off)
 
   for pkg in (basename $OMF_PATH/pkg/*)
-    omf.remove_package $pkg >/dev/null ^&1
+    emit uninstall_$pkg
   end
 
   set -l fish_config $XDG_CONFIG_HOME/fish


### PR DESCRIPTION
When calling `omf destroy`, the `bundle` file is completely erased
because we are calling `remove_package` on each installed package. We
don't want to erase that file, we just want to emit the event and later
on remove the code, which is done with `rm -rf "$OMF_PATH"`.