### PR TITLE
Rework omf theme code: Integrate with fish_config, ditch refresh calls

### DIFF
--- a/pkg/omf/cli/omf.check.fish_prompt.fish
+++ b/pkg/omf/cli/omf.check.fish_prompt.fish
@@ -1,0 +1,10 @@
+function omf.check.fish_prompt
+  set -l prompt_file "fish_prompt.fish"
+  set -l theme (cat $OMF_CONFIG/theme)
+
+  set -l user_functions_path (omf.xdg.config_home)/fish/functions
+  set -l fish_prompt (readlink "$user_functions_path/$prompt_file" ^/dev/null)
+
+  not test -e "$fish_prompt"; and return 0
+  contains -- "$fish_prompt" {$OMF_CONFIG,$OMF_PATH}/themes/$theme/$prompt_file
+end

--- a/pkg/omf/cli/omf.doctor.fish
+++ b/pkg/omf/cli/omf.doctor.fish
@@ -1,5 +1,5 @@
 function __omf.doctor.theme
-  if test -e ~/.config/fish/functions/fish_prompt.fish
+  if not omf.check.fish_prompt
     echo (omf::err)"Warning: "(omf::off)(omf::em)"fish_prompt.fish"(omf::off)" is overridden."
     echo (omf::em)"  fish_config"(omf::off)" command persists the prompt to "(omf::em)"~/.config/fish/functions/fish_prompt.fish"(omf::off)
     echo "  That file takes precedence over Oh My Fish's themes. Remove the file to fix it:"

--- a/pkg/omf/cli/omf.install.fish
+++ b/pkg/omf/cli/omf.install.fish
@@ -5,7 +5,6 @@ function omf.install -a type_flag name_or_url
 
   function _display_error
     echo (omf::err)"Could not install $argv."(omf::off) 1^&2
-    return $OMF_UNKNOWN_ERR
   end
 
   switch $type_flag
@@ -31,8 +30,10 @@ function omf.install -a type_flag name_or_url
       if omf.repo.clone $name_or_url $OMF_PATH/$parent_path/$local_name
         omf.bundle.add $install_type $name_or_url
         _display_success "$install_type $name_or_url"
+
       else
         _display_error "$install_type $name_or_url"
+        return $OMF_UNKNOWN_ERR
       end
     end
     return 0
@@ -49,6 +50,9 @@ function omf.install -a type_flag name_or_url
       _display_success "$install_type $name_or_url"
     else
       _display_error "$install_type $name_or_url"
+      return $OMF_UNKNOWN_ERR
     end
   end
+
+  return 0
 end

--- a/pkg/omf/cli/omf.install.fish
+++ b/pkg/omf/cli/omf.install.fish
@@ -30,7 +30,6 @@ function omf.install -a type_flag name_or_url
       if omf.repo.clone $name_or_url $OMF_PATH/$parent_path/$local_name
         omf.bundle.add $install_type $name_or_url
         _display_success "$install_type $name_or_url"
-
       else
         _display_error "$install_type $name_or_url"
         return $OMF_UNKNOWN_ERR

--- a/pkg/omf/cli/omf.theme.fish
+++ b/pkg/omf/cli/omf.theme.fish
@@ -1,6 +1,31 @@
-function omf.theme
-  if not test -e $OMF_CONFIG/themes/$argv[1]
-    omf.install --theme $argv[1]
+function omf.theme -a target_theme
+  set -l current_theme (cat $OMF_CONFIG/theme)
+  test "$target_theme" = "$current_theme"; and return 0
+
+  set -l prompt_filename "fish_prompt.fish"
+  set -l user_functions_path (omf.xdg.config_home)/fish/functions
+
+  mkdir -p "$user_functions_path"
+
+  if not omf.check.fish_prompt
+    echo (omf::err)"Conflicting prompt setting."(omf::off)
+    echo "Run "(omf::em)"omf doctor"(omf::off)" and fix issues before continuing."
+    return 1
   end
-  echo "$argv[1]" > $OMF_CONFIG/theme
+
+  # Replace autoload paths of current theme with the target one
+  autoload -e {$OMF_CONFIG,$OMF_PATH}/themes/$current_theme
+  autoload {$OMF_CONFIG,$OMF_PATH}/themes/$target_theme
+
+  # Find target theme's fish_prompt and link to user function path
+  for path in {$OMF_CONFIG,$OMF_PATH}/themes/$target_theme/$prompt_filename
+    if test -e $path
+      ln -sf $path $user_functions_path/$prompt_filename; and break
+    end
+  end
+
+  # Persist the changes
+  echo "$target_theme" > "$OMF_CONFIG/theme"
+
+  return 0
 end

--- a/pkg/omf/cli/omf.xdg.config_home.fish
+++ b/pkg/omf/cli/omf.xdg.config_home.fish
@@ -1,0 +1,5 @@
+function omf.xdg.config_home -d "Return the config directory based on XDG specs"
+  set -q XDG_CONFIG_HOME;
+    and echo "$XDG_CONFIG_HOME";
+    or echo "$HOME/.config"
+end

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -120,10 +120,11 @@ function omf -d "Oh My Fish"
 
         omf.list_themes | column | sed -E "s/$regex/"(omf::em)"\1"(omf::off)"/"
         omf::off
-
       else if test (count $argv) -eq 2
+        if not contains -- $argv[2] (omf.list_installed_themes)
+          omf.install --theme $argv[2]; or return 1
+        end
         omf.theme $argv[2]
-        refresh
       else
         echo (omf::err)"Invalid number of arguments"(omf::off) 1^&2
         echo "Usage: $_ "(omf::em)"$argv[1]"(omf::off)" [<theme name>]" 1^&2


### PR DESCRIPTION
**Depends upon #99**

The activation of a theme is now done in two phases of four steps:

+ Theme validation
  - If not installed, install target theme
  - Locate the current and target theme in `$OMF_CONFIG` or `$OMF_PATH`
  - Check existence or create fish user function path
  - Check for conflicting `fish_prompt`, abort if found
+ Theme activation
  - Remove current theme from autoloading paths
  - Add target theme to autoloading path
  - Persist selected theme to `$OMF_CONFIG/theme`
  - Link target theme's `fish_prompt` to user's

This approach brings two major advantages:

- Theme prompt now shows accordingly in `fish_config` web interface
- Faster theme changes, reducing it from seconds to some milis
- Avoids calling refresh, which makes users much more happy

Results:

* A faster theme changing experiece
![Screencast](http://cl.ly/image/1N0n1r0I1J1B/download/Screen%20Recording%202015-10-04%20at%2008.14%20PM.gif)

* Integration with fish_config
![Fish Config Screenshot](http://cl.ly/image/3W091z1k2H1b/download/Image%202015-10-04%20at%209.04.36%20PM.png)