### PR TITLE
Fix omf.destroy: -regextype doesn't exist on find BSD.

### DIFF
--- a/pkg/omf/cli/omf.destroy.fish
+++ b/pkg/omf/cli/omf.destroy.fish
@@ -5,12 +5,16 @@ function omf.destroy -d "Remove Oh My Fish"
     emit uninstall_$pkg
   end
 
-  set -l fish_config $XDG_CONFIG_HOME/fish
+  set -l fish_config "$XDG_CONFIG_HOME/fish"
   if test "$fish_config" = "/fish"
     set fish_config $HOME/.config/fish
   end
 
-  set -l localbackup (find $fish_config -regextype posix-extended -regex '^.*fish/config\.[[:digit:]]+\.copy$' |\
+  set -l find_argument
+  if find -version ^/dev/null| grep -q GNU
+    set find_argument -regextype posix-basic
+  end;
+  set -l localbackup (find $fish_config $find_argument -regex '^.*fish/config\.[[:digit:]]\+\.copy$' |\
     sort -r |head -1)
   if test -n $localbackup
     mv $localbackup "$fish_config/config.fish"


### PR DESCRIPTION
fish_config wasn't properly initialised.
GNU find use emacs regex by default. force using posix-basic (default of BSD find) 
