### PR TITLE
bundle.add: fix theme being persisted twice

### DIFF
--- a/pkg/omf/cli/omf.bundle.add.fish
+++ b/pkg/omf/cli/omf.bundle.add.fish
@@ -1,25 +1,14 @@
 function omf.bundle.add -a type name_or_url
-  function __omf.write_bundle
-    set -l bundle $OMF_CONFIG/bundle
-    set -l record $argv
+  set -l bundle $OMF_CONFIG/bundle
+  set -l record "$type $name_or_url"
 
-    if test -f $bundle
-      if not grep $record $bundle > /dev/null 2>&1
-        echo $record >> $bundle
-      end
-    else
-      echo $record > $bundle
+  if test -f $bundle
+    if not grep $record $bundle > /dev/null 2>&1
+      echo $record >> $bundle
     end
-
-    sort -u $bundle -o $bundle
+  else
+    echo $record > $bundle
   end
 
-  function __omf.write_theme
-    echo $argv > $OMF_CONFIG/theme
-  end
-
-  __omf.write_bundle "$type" "$name_or_url"
-  if test "$type" = theme
-    __omf.write_theme "$name_or_url"
-  end
+  sort -u $bundle -o $bundle
 end


### PR DESCRIPTION
`omf theme` was persisting the installed theme twice, one time on `omf.install` and other time on `omf.bundle.add`.