### PR TITLE
Fixes a regression in update process added in #115

### DIFF
--- a/pkg/omf/cli/omf.list_installed_packages.fish
+++ b/pkg/omf/cli/omf.list_installed_packages.fish
@@ -1,0 +1,5 @@
+# Backwards-compatible wrapper function
+# TODO: Remove it after 2015, December 13
+function omf.list_installed_packages
+  omf.packages.list --installed --plugin
+end


### PR DESCRIPTION
As #115 migrated list functions, after updating Oh My Fish code
the omf.list_installed_packages gets removed, but is still being
used by the update code.

This commit fixes it by providing a wrapper function.