### PR TITLE
Overhaul install and update code

### DIFF
--- a/pkg/omf/cli/omf.install.fish
+++ b/pkg/omf/cli/omf.install.fish
@@ -1,54 +1,47 @@
-function omf.install -a type_flag name_or_url
-  function _display_success
+function omf.install -a name_or_url
+  function __omf.install.success
     echo (omf::em)"✔ $argv successfully installed."(omf::off)
   end
 
-  function _display_error
+  function __omf.install.error
     echo (omf::err)"Could not install $argv."(omf::off) 1^&2
   end
 
-  switch $type_flag
-    case "--theme"
-      set install_type "theme"
-      set parent_path "themes"
-    case "--pkg"
-      set install_type "package"
-      set parent_path "pkg"
-    case "*"
-      echo (omf::err)"Argument to omf.install must be --theme [name|URL] or --pkg [name|URL]"(omf::off)
-      return $OMF_INVALID_ARG
+  if test \( -e $OMF_PATH/db/themes/$name_or_url \) -o (echo $name_or_url | grep theme-)
+    set install_type "theme"
+    set parent_path "themes"
+  else
+    set install_type "package"
+    set parent_path "pkg"
   end
 
   if test -e $OMF_PATH/db/$parent_path/$name_or_url
-    set target $parent_path/$name_or_url
+    set name $name_or_url
+    set url (cat $OMF_PATH/db/$parent_path/$name_or_url)
   else
-    set -l local_name (basename $name_or_url | sed "s/^pkg-//;s/^plugin-//;s/^theme-//")
-    if test -e $OMF_PATH/$parent_path/$local_name
-      echo (omf::err)"Error: $local_name $install_type already installed."(omf::off) 1^&2
-    else
-      echo (omf::dim)"Trying to clone from URL..."(omf::off)
-      if omf.repo.clone $name_or_url $OMF_PATH/$parent_path/$local_name
-        omf.bundle.add $install_type $name_or_url
-        _display_success "$install_type $name_or_url"
-      else
-        _display_error "$install_type $name_or_url"
-        return $OMF_UNKNOWN_ERR
-      end
-    end
-    return 0
+    set name (basename $name_or_url | sed "s/^pkg-//;s/^plugin-//;s/^theme-//")
+    set url $name_or_url
   end
 
-  if test -e $OMF_PATH/$target
-    echo (omf::dim)"Updating $name_or_url $install_type..."(omf::off)
-    omf.repo.pull $OMF_PATH/$target
-    echo (omf::em)"✔ $name_or_url $install_type up to date."(omf::off)
-  else
-    echo (omf::dim)"Installing $name_or_url $install_type..."(omf::off)
-    if omf.repo.clone (cat $OMF_PATH/db/$target) $OMF_PATH/$target
-      omf.bundle.add $install_type $name_or_url
-      _display_success "$install_type $name_or_url"
+  if test -e $OMF_PATH/$parent_path/$name
+    if test "$install_type" = theme
+      omf.theme $name
     else
-      _display_error "$install_type $name_or_url"
+      echo (omf::err)"Error: $name $install_type already installed."(omf::off) 1^&2
+      return $OMF_INVALID_ARG
+    end
+  else
+    echo (omf::dim)"Installing $install_type $name"(omf::off)
+
+    if omf.repo.clone $url $OMF_PATH/$parent_path/$name
+      omf.bundle.add $install_type $name_or_url
+      __omf.install.success "$install_type $name"
+
+      if test "$install_type" = theme
+        omf.theme $name
+      end
+    else
+      __omf.install.error "$install_type $name"
       return $OMF_UNKNOWN_ERR
     end
   end

--- a/pkg/omf/cli/omf.install.fish
+++ b/pkg/omf/cli/omf.install.fish
@@ -19,7 +19,7 @@ function omf.install -a name_or_url
     set name $name_or_url
     set url (cat $OMF_PATH/db/$parent_path/$name_or_url)
   else
-    set name (basename $name_or_url | sed "s/^pkg-//;s/^plugin-//;s/^theme-//")
+    set name (basename $name_or_url | sed 's/^pkg-//;s/^plugin-//;s/^theme-//;s/\.git$//')
     set url $name_or_url
   end
 

--- a/pkg/omf/cli/omf.install_package.fish
+++ b/pkg/omf/cli/omf.install_package.fish
@@ -1,5 +1,5 @@
 function omf.install_package
   for search in $argv
-    omf.install --pkg $search
+    omf.install $search
   end
 end

--- a/pkg/omf/cli/omf.packages.list.fish
+++ b/pkg/omf/cli/omf.packages.list.fish
@@ -2,11 +2,15 @@ function __omf.packages.sort
   for package in (echo $argv | tr ' ' '\n' | sort); echo $package; end
 end
 
+function __omf.packages.builtin
+  echo "omf"
+end
+
 function __omf.packages.list -a type
   set -l list
 
   test "$type" = "--theme"; or for package in (basename {$OMF_CONFIG,$OMF_PATH/db}/pkg/*)
-    set list $list $package
+    contains $package (__omf.packages.builtin); or set list $list $package
   end
 
   test "$type" = "--plugin"; or for package in (basename {$OMF_CONFIG,$OMF_PATH/db}/themes/*)
@@ -48,7 +52,7 @@ function __omf.packages.list.installed -a type
   set -l list
 
   test "$type" = "--theme"; or for package in (basename {$OMF_CONFIG,$OMF_PATH}/pkg/*)
-    set list $list $package
+    contains $package (__omf.packages.builtin); or set list $list $package
   end
 
   test "$type" = "--plugin"; or for package in (basename {$OMF_CONFIG,$OMF_PATH}/themes/*)

--- a/pkg/omf/cli/omf.theme.fish
+++ b/pkg/omf/cli/omf.theme.fish
@@ -1,4 +1,10 @@
 function omf.theme -a target_theme
+  if not contains "$target_theme" (omf.packages.list --installed --theme)
+    echo (omf::err)"Theme not installed!"(omf::off)
+    echo Install it using (omf::em)omf install $target_theme(omf::off)
+    return $OMF_INVALID_ARG
+  end
+
   set -l current_theme (cat $OMF_CONFIG/theme)
   test "$target_theme" = "$current_theme"; and return 0
 
@@ -10,7 +16,7 @@ function omf.theme -a target_theme
   if not omf.check.fish_prompt
     echo (omf::err)"Conflicting prompt setting."(omf::off)
     echo "Run "(omf::em)"omf doctor"(omf::off)" and fix issues before continuing."
-    return 1
+    return $OMF_INVALID_ARG
   end
 
   # Replace autoload paths of current theme with the target one

--- a/pkg/omf/cli/omf.update.fish
+++ b/pkg/omf/cli/omf.update.fish
@@ -1,0 +1,25 @@
+function omf.update -a name
+  function __omf.update.success
+    echo (omf::em)"✔ $argv successfully updated."(omf::off)
+  end
+
+  function __omf.update.error
+    echo (omf::err)"Could not update $argv."(omf::off) 1^&2
+  end
+
+  if test \( -e $OMF_PATH/themes/$name \) -o \( -e $OMF_CONFIG/themes/$name \)
+    set install_type "theme"
+    set parent_path "themes"
+  else
+    set install_type "package"
+    set parent_path "pkg"
+  end
+
+  for path in {$OMF_PATH,$OMF_CONFIG}/pkg/$name
+    not test -e "$path/.git"; and continue
+
+    omf.repo.pull $path; and set return_success
+  end
+
+  set -q return_success; and __omf.update.success "$name"
+end

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -78,7 +78,10 @@ function omf -d "Oh My Fish"
       if test (count $argv) -eq 1
         omf.bundle.install
       else
-        omf.install_package $argv[2..-1]
+        for package in $argv[2..-1]
+          omf.install $package
+        end
+
         refresh
       end
 
@@ -121,9 +124,6 @@ function omf -d "Oh My Fish"
         omf.packages.list --database --theme | column | sed -E "s/$regex/"(omf::em)"\1"(omf::off)"/"
         omf::off
       else if test (count $argv) -eq 2
-        if not contains -- $argv[2] (omf.packages.list --installed)
-          omf.install --theme $argv[2]; or return 1
-        end
         omf.theme $argv[2]
       else
         echo (omf::err)"Invalid number of arguments"(omf::off) 1^&2

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -139,10 +139,12 @@ function omf -d "Oh My Fish"
         echo (omf::err)"Oh My Fish failed to update."(omf::off)
         echo "Please open a new issue here → "(omf::em)"github.com/oh-my-fish/oh-my-fish/issues"(omf::off)
       end
-      omf.theme (cat $OMF_CONFIG/theme)
-      omf.install_package (omf.packages.list --installed --plugin)
-      refresh
 
+      for package in (omf.packages.list --installed)
+        omf.update $package
+      end
+
+      refresh
     case "*"
       echo (omf::err)"$argv[1] option not recognized"(omf::off) 1^&2
       return $OMF_UNKNOWN_OPT

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -79,10 +79,12 @@ function omf -d "Oh My Fish"
         omf.bundle.install
       else
         for package in $argv[2..-1]
-          omf.install $package
+          if omf.install $package
+            set refresh
+          end
         end
 
-        refresh
+        set -q refresh; and refresh
       end
 
     case "l" "ls" "list"


### PR DESCRIPTION
This series breaks install code monolith by splitting
the update code out of it and also by rewriting install
code.

Also fixes some known issues:

- #119 which tries to update local packages and even
omf package
- Installing plugins form URLs ended in `.git` now
works correctly
- When using `omf install <package>`, don't refresh 
the shell if nothing was installed

This series also changes the behavior of `omf theme`,
which now don't install or update themes when used,
rather displaying a message guiding the user to use
`omf install`.