### PR TITLE
pkg/omf/init.fish: source `omf.fish` as part of omf's init

### DIFF
--- a/pkg/omf/init.fish
+++ b/pkg/omf/init.fish
@@ -1,3 +1,19 @@
 function init -a path --on-event init_omf
   autoload $path/cli $path/util
 end
+
+function omf::em
+  set_color $fish_color_match ^/dev/null; or set_color cyan
+end
+
+function omf::dim
+  set_color $fish_color_autosuggestion ^/dev/null; or set_color 555
+end
+
+function omf::err
+  set_color $fish_color_error ^/dev/null; or set_color red --bold
+end
+
+function omf::off
+  set_color normal
+end

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -13,22 +13,6 @@ set -g OMF_UNKNOWN_OPT   2
 set -g OMF_INVALID_ARG   3
 set -g OMF_UNKNOWN_ERR   4
 
-function omf::em
-  set_color $fish_color_match ^/dev/null; or set_color cyan
-end
-
-function omf::dim
-  set_color $fish_color_autosuggestion ^/dev/null; or set_color 555
-end
-
-function omf::err
-  set_color $fish_color_error ^/dev/null; or set_color red --bold
-end
-
-function omf::off
-  set_color normal
-end
-
 function omf -d "Oh My Fish"
   if test (count $argv) -eq 0
     omf.help "main"; and return 0


### PR DESCRIPTION
Since ceb31c1, functions defined by omf package – namely `omf::em`, `omf::dim`, `omf::err`, `omf::off` and `omf` – are not being sourced.