### PR TITLE
require: Cleanup previously sourced init functions

### DIFF
--- a/lib/require.fish
+++ b/lib/require.fish
@@ -23,4 +23,8 @@ function require -a name
         and emit init_$name $path
     end
   end
+
+  functions -e init  # Cleanup previously sourced function
+
+  return 0
 end


### PR DESCRIPTION
`require` sources plugin's `init.fish` files, which are supposed to
declare an `init` function. Although we source the file, we aren't
cleaning up the declared function. This PR fixes this.