### PR TITLE
Rewrite bundle install to conform with latest `omf.install` interface

### DIFF
--- a/pkg/omf/cli/omf.bundle.install.fish
+++ b/pkg/omf/cli/omf.bundle.install.fish
@@ -2,30 +2,28 @@ function omf.bundle.install
   set bundle $OMF_CONFIG/bundle
 
   if test -f $bundle
-    set packages (omf.packages.list --installed --plugin)
-    set themes (omf.packages.list --installed --theme)
+    set packages (omf.packages.list --installed)
     set bundle_contents (cat $bundle | sort -u)
 
     for record in $bundle_contents
-      set type (echo $record | cut -d' ' -f1)
-      set name_or_url (echo $record | cut -d' ' -f2-)
+      test -n "$record"; or continue
+
+      set type (echo $record | cut -s -d' ' -f1 | sed 's/ //g')
+      contains $type theme package; or continue
+
+      set name_or_url (echo $record | cut -s -d' ' -f2- | sed 's/ //g')
+      test -n "$name_or_url"; or continue
+
       set name (basename $name_or_url | sed 's/\.git//;s/^pkg-//;s/^plugin-//;s/^theme-//')
 
-      switch $type
-      case "package"
-        if not contains $name $packages
-          omf.install --pkg $name_or_url
-        end
-
-      case "theme"
-        if not contains $name $themes
-          omf.install --theme $name_or_url
-        end
+      if not contains $name $packages
+        omf.install $name_or_url;
+          and set installed
       end
     end
 
     sort -u $bundle -o $bundle
   end
 
-  return 0
+  set -q installed
 end

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -76,16 +76,17 @@ function omf -d "Oh My Fish"
 
     case "i" "install" "get"
       if test (count $argv) -eq 1
-        omf.bundle.install
+        omf.bundle.install;
+          and set installed
       else
         for package in $argv[2..-1]
-          if omf.install $package
-            set refresh
-          end
+          omf.install $package;
+            and set installed
         end
-
-        set -q refresh; and refresh
       end
+
+      set -q installed; and refresh
+      return 0
 
     case "l" "ls" "list"
       omf.packages.list --installed | column


### PR DESCRIPTION
Rewrites the code, as now `omf.install` is type
agnostic, and any -- preceded parameter will
be interpreted as package name.

In case of #123 it was breaking on a 
`basename` call just for the fun of
debugging :trollface:.