### PR TITLE
omf/templates: Align README headers based on omf's

### DIFF
--- a/pkg/omf/templates/pkg/README.md
+++ b/pkg/omf/templates/pkg/README.md
@@ -1,15 +1,13 @@
-![][license-badge]
+<img src="https://cdn.rawgit.com/oh-my-fish/oh-my-fish/e4f1c2e0219a17e2c748b824004c8d0b38055c16/docs/logo.svg" align="left" width="144px" height="144px"/>
 
-<div align="center">
-  <a href="http://github.com/oh-my-fish/oh-my-fish">
-  <img width=90px  src="https://cloud.githubusercontent.com/assets/8317250/8510172/f006f0a4-230f-11e5-98b6-5c2e3c87088f.png">
-  </a>
-</div>
-<br>
+#### {{NAME}}
+> A plugin for [Oh My Fish][omf-link].
 
-# {{NAME}}
+[![MIT License](https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square)](/LICENSE)
+[![Fish Shell Version](https://img.shields.io/badge/fish-v2.2.0-007EC7.svg?style=flat-square)](http://fishshell.com)
+[![Oh My Fish Framework](https://img.shields.io/badge/Oh%20My%20Fish-Framework-007EC7.svg?style=flat-square)](https://www.github.com/oh-my-fish/oh-my-fish)
 
-Plugin for [Oh My Fish][omf-link].
+<br/>
 
 ## Install
 

--- a/pkg/omf/templates/themes/README.md
+++ b/pkg/omf/templates/themes/README.md
@@ -1,17 +1,19 @@
-<div align="center">
-  <a href="http://github.com/oh-my-fish/oh-my-fish">
-  <img width=90px  src="https://cloud.githubusercontent.com/assets/8317250/8510172/f006f0a4-230f-11e5-98b6-5c2e3c87088f.png">
-  </a>
-</div>
-<br>
+<img src="https://cdn.rawgit.com/oh-my-fish/oh-my-fish/e4f1c2e0219a17e2c748b824004c8d0b38055c16/docs/logo.svg" align="left" width="144px" height="144px"/>
 
-> {{NAME}} theme for [Oh My Fish][omf-link].
+#### {{NAME}}
+> A theme for [Oh My Fish][omf-link].
+
+[![MIT License](https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square)](/LICENSE)
+[![Fish Shell Version](https://img.shields.io/badge/fish-v2.2.0-007EC7.svg?style=flat-square)](http://fishshell.com)
+[![Oh My Fish Framework](https://img.shields.io/badge/Oh%20My%20Fish-Framework-007EC7.svg?style=flat-square)](https://www.github.com/oh-my-fish/oh-my-fish)
+
+<br/>
 
 ## Install
 
 
 ```fish
-$ omf u {{NAME}}
+$ omf install {{NAME}}
 ```
 
 ## Features


### PR DESCRIPTION
Changes the scaffolded theme/plugin README, including a new, revamped look, more aligned with current Oh My Fish README. This PR happens to fix two additional items:

- [x] LICENSE badge link was wrong, pointing to README.md
- [x] The way themes are installed now is using `omf install`