### PR TITLE
omf.repo.pull: Use helper functions to fix code repetition

### DIFF
--- a/pkg/omf/cli/omf.repo.pull.fish
+++ b/pkg/omf/cli/omf.repo.pull.fish
@@ -1,49 +1,61 @@
 function omf.repo.pull
+
   if test (count $argv) -eq 0
     echo (omf::err)"Argument of omf.repo.pull is the repo path."(omf::off)
     return $OMF_MISSING_ARG
   end
+
   set -l repo_dir $argv[1]
 
-  if test (command git --git-dir "$repo_dir"/.git --work-tree "$repo_dir" config --get remote.upstream.url)
-    set repository upstream
-  else
-    set repository origin
+  function omf.repo.git -V repo_dir
+    command git --git-dir "$repo_dir"/.git --work-tree "$repo_dir" $argv
   end
 
-  set initial_branch (command git --git-dir "$repo_dir"/.git --work-tree "$repo_dir" symbolic-ref -q --short HEAD); or return $OMF_UNKNOWN_ERR
-  set initial_revision (command git --git-dir "$repo_dir"/.git --work-tree "$repo_dir" rev-parse -q --verify HEAD); or return $OMF_UNKNOWN_ERR
+  function omf.repo.git.stash -V repo_dir
+    command git -C "$repo_dir" stash $argv
+  end
 
-  if not command git --git-dir "$repo_dir"/.git --work-tree "$repo_dir" diff --quiet
+  set -l remote origin
+  if test (omf.repo.git config --get remote.upstream.url)
+    set remote upstream
+  end
+
+  set initial_branch (omf.repo.git symbolic-ref -q --short HEAD);
+    or return $OMF_UNKNOWN_ERR
+  set initial_revision (omf.repo.git rev-parse -q --verify HEAD);
+    or return $OMF_UNKNOWN_ERR
+
+  if not omf.repo.git diff --quiet
     echo (omf::em)"Stashing your changes:"(omf::off)
-    command git -C "$repo_dir" status --short --untracked-files
-
-    command git -C "$repo_dir" stash save --include-untracked --quiet
-    set stashed
+    omf.repo.git status --short --untracked-files
+    omf.repo.git.stash save --include-untracked --quiet;
+      and set stashed
   end
 
   if test "$initial_branch" != master
-    command git --git-dir "$repo_dir"/.git --work-tree "$repo_dir" checkout master --quiet
+    omf.repo.git checkout master --quiet
   end
 
-  # the refspec ensures that '$repository/master' gets updated
-  command git --git-dir "$repo_dir"/.git --work-tree "$repo_dir" pull --rebase --quiet $repository "refs/heads/master:refs/remotes/$repository/master"
-  if test $status -eq 2 #SIGINT
-    command git --git-dir "$repo_dir"/.git --work-tree "$repo_dir" checkout $initial_branch
-    command git --git-dir "$repo_dir"/.git --work-tree "$repo_dir" reset --hard $initial_revision
-    set -q stashed; and command git -C "$repo_dir" stash pop
+  set -l refspec "refs/heads/master:refs/remotes/$remote/master"
+
+  # the refspec ensures that '$remote/master' gets updated
+  if not omf.repo.git pull --ff-only --quiet $remote $refspec
+    omf.repo.git checkout $initial_branch
+    omf.repo.git reset --hard $initial_revision
+    set -q stashed; and omf.repo.git.stash pop
   end
 
   if test "$initial_branch" != master
-    command git --git-dir "$repo_dir"/.git --work-tree "$repo_dir" checkout $initial_branch --quiet
+    omf.repo.git checkout $initial_branch --quiet
   end
 
   if set -q stashed
-    command git -C "$repo_dir" stash pop --quiet
+    omf.repo.git.stash pop --quiet
 
     echo (omf::em)"Restored your changes:"(omf::off)
     command git -C "$repo_dir" status --short --untracked-files
   end
 
+  functions -e omf.repo.git{,.stash}
   return 0
 end


### PR DESCRIPTION
This PR gives some Dont Repeat Yourself to `omf.repo.pull`.

It does it by defining functions which inherit the boring and repetitive git repository flags (`--git-dir "$repo_dir"/.git --work-tree "$repo_dir"`). This way the code almost fits in 80 columns :stuck_out_tongue: 

This is in very RFC state. Please review :+1: 