### PR TITLE
registry: add vcs plugin

### DIFF
--- a/db/pkg/vcs
+++ b/db/pkg/vcs
@@ -1,0 +1,1 @@
+https://github.com/oh-my-fish/plugin-vcs.git


### PR DESCRIPTION
Add VCS plugin to registry. This plugin aims to be a dependency for themes which want to display version control related stuff. Currently the supported VCS are Git,  Mercurial and SVN.

The plugin is optimised for speed and performs very well when using Git, which is fast by nature. While using Mercurial we depend on `hg` speed, and thus, it's slower than Git. The same applies to SVN.

The API docs is still TBD, but it's not impeditive to the merge, IMHO. I also have a version of default theme which is already migrated to vcs plugin in work conditions, and the idea is to start migrating themes by it.