### PR TITLE
Implement automatic dependency resolution

### DIFF
--- a/lib/require.fish
+++ b/lib/require.fish
@@ -4,6 +4,7 @@
 # OVERVIEW
 #   Require a plugin:
 #     - Autoload its functions and completions.
+#     - Require bundle dependencies.
 #     - Source its initialization file.
 #     - Emit its initialization event.
 #
@@ -16,7 +17,17 @@ function require -a name
     and return 0
 
   for path in {$OMF_PATH,$OMF_CONFIG}/pkg/$name
+    test -d $path; or continue
+
     if autoload $path $path/functions $path/completions
+
+      if test -f $path/bundle
+        for line in (cat $path/bundle)
+          test (echo $line | cut -d' ' -f1) = package;
+            and set dependency (basename (echo $line | cut -d' ' -f2));
+              and require $dependency
+        end
+      end
 
       source $path/init.fish ^/dev/null;
         or source $path/$name.fish ^/dev/null;

--- a/pkg/omf/cli/omf.bundle.install.fish
+++ b/pkg/omf/cli/omf.bundle.install.fish
@@ -1,5 +1,7 @@
 function omf.bundle.install
-  set bundle $OMF_CONFIG/bundle
+  test -n "$argv";
+    and set bundle $argv
+    or set bundle $OMF_CONFIG/bundle
 
   if test -f $bundle
     set packages (omf.packages.list --installed)

--- a/pkg/omf/cli/omf.install.fish
+++ b/pkg/omf/cli/omf.install.fish
@@ -34,6 +34,7 @@ function omf.install -a name_or_url
     echo (omf::dim)"Installing $install_type $name"(omf::off)
 
     if omf.repo.clone $url $OMF_PATH/$parent_path/$name
+      omf.bundle.install $OMF_PATH/$parent_path/$name/bundle
       omf.bundle.add $install_type $name_or_url
       __omf.install.success "$install_type $name"
 

--- a/pkg/omf/cli/omf.update.fish
+++ b/pkg/omf/cli/omf.update.fish
@@ -19,6 +19,9 @@ function omf.update -a name
     not test -e "$path/.git"; and continue
 
     omf.repo.pull $path; and set return_success
+
+    set -q return_success;
+      and omf.bundle.install $path/bundle
   end
 
   set -q return_success; and __omf.update.success "$name"


### PR DESCRIPTION
This PR adds automatic dependency loading to packages. Fixes #64 

Packages must include a `bundle` file in which dependencies are
declared in the same syntax as `$OMF_CONFIG/bundle` file.

On package installation we install the declared bundle.
On shell startup we load the dependencies from the bundle file.
