### PR TITLE
autoload: Use `set -e` to remove components from paths

### DIFF
--- a/lib/autoload.fish
+++ b/lib/autoload.fish
@@ -43,16 +43,10 @@ function autoload -d "Manipulate autoloading path components"
     end
 
     if set -q erase
-      not contains -- "$path" $$dest; and continue
-      # Make a copy of function path selected above
-      set -l function_path $$dest
-
-      set -l index (contains -i -- $path $function_path)
-      set -e function_path[$index]
-
-      # Set function path to modified copy
-      set $dest $function_path
-      set return_success
+      if set -l index (contains -i -- $path $$dest)
+        set -e {$dest}[$index]
+        set return_success
+      end
     else
       set return_success
       contains -- "$path" $$dest; and continue


### PR DESCRIPTION
When using `autoload -e` we currently do a copy of destination function path's content,
modify it and then set it back. This was done as a workaround for using `set -e` with a
precedency issue in `set -e $dest[1]` usage, which is solved by using `set -e {$dest}[1]`.