### PR TITLE
packages.list: Use basename -a with multiple paths

### DIFF
--- a/pkg/omf/cli/omf.destroy.fish
+++ b/pkg/omf/cli/omf.destroy.fish
@@ -14,7 +14,7 @@ end
 function omf.destroy -d "Remove Oh My Fish"
   echo (omf::dim)"Removing Oh My Fish..."(omf::off)
 
-  for pkg in (basename $OMF_PATH/pkg/*)
+  for pkg in (basename -a $OMF_PATH/pkg/*)
     emit uninstall_$pkg
   end
 

--- a/pkg/omf/cli/omf.packages.list.fish
+++ b/pkg/omf/cli/omf.packages.list.fish
@@ -9,11 +9,11 @@ end
 function __omf.packages.list -a type
   set -l list
 
-  test "$type" = "--theme"; or for package in (basename {$OMF_CONFIG,$OMF_PATH/db}/pkg/*)
+  test "$type" = "--theme"; or for package in (basename -a {$OMF_CONFIG,$OMF_PATH/db}/pkg/*)
     contains $package (__omf.packages.builtin); or set list $list $package
   end
 
-  test "$type" = "--plugin"; or for package in (basename {$OMF_CONFIG,$OMF_PATH/db}/themes/*)
+  test "$type" = "--plugin"; or for package in (basename -a {$OMF_CONFIG,$OMF_PATH/db}/themes/*)
     set list $list $package
   end
 
@@ -24,11 +24,11 @@ function __omf.packages.list.available -a type
   set -l list
 
   test "$type" = "--theme"; or for package in (basename $OMF_PATH/db/pkg/*)
-    contains $package (basename {$OMF_CONFIG,$OMF_PATH}/pkg/*); or set list $list $package
+    contains $package (basename -a {$OMF_CONFIG,$OMF_PATH}/pkg/*); or set list $list $package
   end
 
   test "$type" = "--plugin"; or for package in (basename $OMF_PATH/db/themes/*)
-    contains $package (basename {$OMF_CONFIG,$OMF_PATH}/themes/*); or set list $list $package
+    contains $package (basename -a {$OMF_CONFIG,$OMF_PATH}/themes/*); or set list $list $package
   end
 
   __omf.packages.sort $list
@@ -37,11 +37,11 @@ end
 function __omf.packages.list.database -a type
   set -l list
 
-  test "$type" = "--theme"; or for package in (basename $OMF_PATH/db/pkg/*)
+  test "$type" = "--theme"; or for package in (basename -a $OMF_PATH/db/pkg/*)
     set list $list $package
   end
 
-  test "$type" = "--plugin"; or for package in (basename $OMF_PATH/db/themes/*)
+  test "$type" = "--plugin"; or for package in (basename -a $OMF_PATH/db/themes/*)
     set list $list $package
   end
 
@@ -51,11 +51,11 @@ end
 function __omf.packages.list.installed -a type
   set -l list
 
-  test "$type" = "--theme"; or for package in (basename {$OMF_CONFIG,$OMF_PATH}/pkg/*)
+  test "$type" = "--theme"; or for package in (basename -a {$OMF_CONFIG,$OMF_PATH}/pkg/*)
     contains $package (__omf.packages.builtin); or set list $list $package
   end
 
-  test "$type" = "--plugin"; or for package in (basename {$OMF_CONFIG,$OMF_PATH}/themes/*)
+  test "$type" = "--plugin"; or for package in (basename -a {$OMF_CONFIG,$OMF_PATH}/themes/*)
     set list $list $package
   end
 


### PR DESCRIPTION
This PR fixes the previously `basename`-function-masked usage of `basename` command.

All `basename`s which receives more than one parameter were converted to `basename -a`.