### PR TITLE
Fix #161 by inverting test argument order 

### DIFF
--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -33,7 +33,7 @@ function omf -d "Oh My Fish"
   if test (count $argv) -eq 0
     omf.help "main"; and return 0
   else
-    if test $argv[-1] = "--help" -a (count $argv) = 2
+    if test "--help" = "$argv[-1]" -a (count $argv) = 2
       omf.help $argv[1..-2]; and return 0
     end
   end


### PR DESCRIPTION
Since `test` interprets arguments starting with a single dash as
options when comparing `test -h = --help` just swap parameter
orders as in `test --help = -h`. Also related to issue #161 is the
issue from fish repository at fish-shell/fish-shell#2332