### PR TITLE
Add wd plugin

### DIFF
--- a/db/pkg/wd
+++ b/db/pkg/wd
@@ -1,0 +1,1 @@
+https://github.com/fischerling/plugin-wd


### PR DESCRIPTION
wd is a plugin to quickly jump to custom directories.

Is there a way to include man pages in a pkg with omf ?
Because wd uses __fish_print_help to output the help message.
And __fish_print_help use the man page stored at $__fish_datadir/man/man1/$item.1