### PR TITLE
Suppress basename usage output

### DIFF
--- a/pkg/omf/cli/omf.packages.list.fish
+++ b/pkg/omf/cli/omf.packages.list.fish
@@ -55,7 +55,7 @@ function __omf.packages.list.installed -a type
     contains $package (__omf.packages.builtin); or set list $list $package
   end
 
-  test "$type" = "--plugin"; or for package in (basename -a {$OMF_CONFIG,$OMF_PATH}/themes/*)
+  test "$type" = "--plugin"; or for package in (basename -a {$OMF_CONFIG,$OMF_PATH}/themes/* 2>/dev/null)
     set list $list $package
   end
 


### PR DESCRIPTION
When using basename without any arguments, a usage helper as following
is displayed:

```
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]
```

When listing the installed packages, if no theme was installed (e.g.
first installation), the `themes/` folder are empty and the usage helper
is displayed. This change addresses it by suppressing the message.