### PR TITLE
readme: Fix wrong link to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Oh My Fish installer places its startup code in your fish config file (`~/.confi
 
 ## Startup
 
-Everytime you open a new shell the startup code initializes Oh My Fish installation path and the _config_ path (`~/.config/omf` by default), sourcing the [`init.fish`](init.fish) script afterwards, which autoload packages, themes and your custom init files. For more information check the [FAQ](docs/FAQ.md#what-does-oh-my-fish-do-exactly).
+Everytime you open a new shell the startup code initializes Oh My Fish installation path and the _config_ path (`~/.config/omf` by default), sourcing the [`init.fish`](init.fish) script afterwards, which autoload packages, themes and your custom init files. For more information check the [FAQ](docs/en-US/FAQ.md#what-does-oh-my-fish-do-exactly).
 
 ## Dotfiles
 


### PR DESCRIPTION
* The English README.md had a link to FAQ that does not work anymore given that it has been localized to `zh-CN` too. This commit makes sure that the link to FAQ in the English article points to the correct part of the correct file.