### PR TITLE
Better organized 'omf theme' output

### DIFF
--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -21,6 +21,10 @@ function omf::dim
   set_color $fish_color_autosuggestion ^/dev/null; or set_color 555
 end
 
+function omf::under
+  set_color --underline
+end
+
 function omf::err
   set_color $fish_color_error ^/dev/null; or set_color red --bold
 end
@@ -119,13 +123,14 @@ function omf -d "Oh My Fish"
 
     case "t" "theme"
       if test (count $argv) -eq 1
-        set -l ostype (uname)
         set -l theme (cat $OMF_CONFIG/theme)
-        set -l regex "[[:<:]]($theme)[[:>:]]"
-        test "$ostype" != "Darwin"; and set regex "\b($theme)\b"
+        set -l highlight_current "(^|[[:space:]])($theme)([[:space:]]|\$)"
 
-        omf.packages.list --database --theme | column | sed -E "s/$regex/"(omf::em)"\1"(omf::off)"/"
-        omf::off
+        echo (omf::under)"Installed:"(omf::off)
+        omf.packages.list --installed --theme | column | sed -E s/"$highlight_current"/"\1"(omf::em)"\2"(omf::off)"\3"/g
+        echo
+        echo (omf::under)"Available:"(omf::off)
+        omf.packages.list --available --theme | column
       else if test (count $argv) -eq 2
         omf.theme $argv[2]
       else


### PR DESCRIPTION
`omf theme` now lists the current, installed and other available themes in different colors to mark their status.
Current theme is emphasized with `omf::em`,
installed themes are displayed normally,
and other available themes are dimmed with `omf::dim`.
Implementation is a bit hacky, but I didn't want to clutter `omf.fish` with very mini-functions specific only to the `theme` sub-command.
Has been tested on Fish 2.2.0, running on Fedora 23 (x64).
Mac OSX behavior should still be tested before merging to master (different `sed` syntax?)

**Edit:**

1. I fixed the editing errors of the last commit, please reconsider. Sorry for wasting your time with a faulty submission.
2. The regular expression that was supposed to highlight the current theme allowed partial matches, so that when applying the agnoster theme, for example, the token _agnoster_ would be highlighted both in **agnoster** and **agnoster**-mercurial.
3. As previously noted, implementation is somewhat patchy. It assumes that no theme name begins with a '+' or '-' sign. A different approach to distinction of the installed from available themes would be simply to display them separately.

**Edit 2:**
Preview image!
![omf_theme_colorful](https://cloud.githubusercontent.com/assets/679184/11607370/6e1e0126-9b4c-11e5-866c-88a52327af1b.png)
