### PR TITLE
Add homebrew command not found plugin

### DIFF
--- a/db/pkg/homebrew-command-not-found
+++ b/db/pkg/homebrew-command-not-found
@@ -1,0 +1,1 @@
+https://github.com/lfiolhais/plugin-homebrew-command-not-found


### PR DESCRIPTION
This plugin auto loads homebrew command not found.