### PR TITLE
Support omf- prefix for packages

### DIFF
--- a/pkg/omf/cli/omf.bundle.install.fish
+++ b/pkg/omf/cli/omf.bundle.install.fish
@@ -16,7 +16,7 @@ function omf.bundle.install
       set name_or_url (echo $record | cut -s -d' ' -f2- | sed 's/ //g')
       test -n "$name_or_url"; or continue
 
-      set name (basename $name_or_url | sed 's/\.git//;s/^pkg-//;s/^plugin-//;s/^theme-//')
+      set name (omf.package_name $name_or_url)
 
       if not contains $name $packages
         omf.install $name_or_url;

--- a/pkg/omf/cli/omf.bundle.remove.fish
+++ b/pkg/omf/cli/omf.bundle.remove.fish
@@ -10,12 +10,11 @@ function omf.bundle.remove
 
       for record in $bundle_contents
         set record_type (echo $record | cut -d' ' -f1)
-        set record_name (echo $record | cut -d' ' -f2-)
-        set record_basename (basename (echo $record_name | \
-          sed -e 's/\.git$//') | sed 's/^pkg-//;s/^plugin-//;s/^theme-//')
+        set record_name_or_url (echo $record | cut -d' ' -f2-)
+        set record_name (omf.package_name $record_name_or_url)
 
-        if not test "$type" = "$record_type" -a "$name" = "$record_basename"
-          echo "$record_type $record_name" >> $bundle
+        if not test "$type" = "$record_type" -a "$name" = "$record_name"
+          echo "$record_type $record_name_or_url" >> $bundle
         end
       end
     end

--- a/pkg/omf/cli/omf.install.fish
+++ b/pkg/omf/cli/omf.install.fish
@@ -17,9 +17,9 @@ function omf.install -a name_or_url
 
   if test -e $OMF_PATH/db/$parent_path/$name_or_url
     set name $name_or_url
-    set url (cat $OMF_PATH/db/$parent_path/$name_or_url)
+    set url (cat $OMF_PATH/db/$parent_path/$name)
   else
-    set name (basename $name_or_url | sed 's/^pkg-//;s/^plugin-//;s/^theme-//;s/\.git$//')
+    set name (omf.package_name $name_or_url)
     set url $name_or_url
   end
 

--- a/pkg/omf/util/omf.package_name.fish
+++ b/pkg/omf/util/omf.package_name.fish
@@ -1,0 +1,3 @@
+function omf.package_name -a name_or_url
+  basename $name_or_url | sed -E 's/^(omf-)?((plugin|pkg|theme)-)?//;s/.git$//'
+end


### PR DESCRIPTION
As requested in #152.
Does not solve #191. Prefer to infer package type from metadata in `package` file, as suggested in #196.