### PR TITLE
omf update: Report up-to-date packages as such

### DIFF
--- a/pkg/omf/functions/packages/omf.packages.update.fish
+++ b/pkg/omf/functions/packages/omf.packages.update.fish
@@ -4,15 +4,20 @@ function omf.packages.update -a name
     not test -e $target_path/.git;
       and return 0
 
-    if omf.repo.pull $target_path
-      omf.bundle.install $target_path/bundle
-      echo (omf::em)"$name successfully updated."(omf::off)
-      return 0
-    else
-      echo (omf::err)"Could not update $name."(omf::off) 1^&2
+    omf.repo.pull $target_path
+    switch $status
+      case 0
+        omf.bundle.install $target_path/bundle
+        echo (omf::em)"$name successfully updated."(omf::off)
+        return 0
+      case 1
+        echo (omf::err)"Could not update $name."(omf::off) 1>&2
+      case 2
+        echo (omf::dim)"$name is already up-to-date."(omf::off)
+        return 0
     end
   else
-    echo (omf::err)"Could not find $name."(omf::off) 1^&2
+    echo (omf::err)"Could not find $name."(omf::off) 1>&2
   end
 
   return 1

--- a/pkg/omf/functions/repo/omf.repo.pull.fish
+++ b/pkg/omf/functions/repo/omf.repo.pull.fish
@@ -1,61 +1,63 @@
 function omf.repo.pull
 
   if test (count $argv) -eq 0
-    echo (omf::err)"Argument of omf.repo.pull is the repo path."(omf::off)
+    echo (omf::err)"omf.repo.pull takes a repository path as an argument."(omf::off) 1>&2
     return $OMF_MISSING_ARG
   end
 
   set -l repo_dir $argv[1]
 
-  function omf.repo.git -V repo_dir
-    command git --git-dir "$repo_dir"/.git --work-tree "$repo_dir" $argv
-  end
-
-  function omf.repo.git.stash -V repo_dir
-    command git -C "$repo_dir" stash $argv
+  function __omf.repo.git -V repo_dir
+    command git -C "$repo_dir" $argv
   end
 
   set -l remote origin
-  if test (omf.repo.git config --get remote.upstream.url)
+  if test (__omf.repo.git config --get remote.upstream.url)
     set remote upstream
   end
 
-  set initial_branch (omf.repo.git symbolic-ref -q --short HEAD);
-    or return $OMF_UNKNOWN_ERR
-  set initial_revision (omf.repo.git rev-parse -q --verify HEAD);
-    or return $OMF_UNKNOWN_ERR
+  set initial_branch (__omf.repo.git symbolic-ref -q --short HEAD);
+    or return 1
+  set initial_revision (__omf.repo.git rev-parse -q --verify HEAD);
+    or return 1
 
-  if not omf.repo.git diff --quiet
+  # the refspec ensures that '$remote/master' gets updated
+  set -l refspec "refs/heads/master:refs/remotes/$remote/master"
+  __omf.repo.git fetch --quiet $remote $refspec;
+    or return 1
+
+  if test (__omf.repo.git rev-list --count master...FETCH_HEAD) -eq 0
+    return 2
+  end
+
+  if not __omf.repo.git diff --quiet
     echo (omf::em)"Stashing your changes:"(omf::off)
-    omf.repo.git status --short --untracked-files
-    omf.repo.git.stash save --include-untracked --quiet;
+    __omf.repo.git status --short --untracked-files
+    __omf.repo.git stash save --include-untracked --quiet;
       and set stashed
   end
 
   if test "$initial_branch" != master
-    omf.repo.git checkout master --quiet
+    __omf.repo.git checkout master --quiet
   end
 
-  set -l refspec "refs/heads/master:refs/remotes/$remote/master"
-
-  # the refspec ensures that '$remote/master' gets updated
-  if not omf.repo.git pull --ff-only --quiet $remote $refspec
-    omf.repo.git checkout $initial_branch
-    omf.repo.git reset --hard $initial_revision
-    set -q stashed; and omf.repo.git.stash pop
+  if not __omf.repo.git merge --ff-only --quiet FETCH_HEAD
+    __omf.repo.git checkout $initial_branch
+    __omf.repo.git reset --hard $initial_revision
+    set -q stashed; and __omf.repo.git stash pop
+    return 1
   end
 
   if test "$initial_branch" != master
-    omf.repo.git checkout $initial_branch --quiet
+    __omf.repo.git checkout $initial_branch --quiet
   end
 
   if set -q stashed
-    omf.repo.git.stash pop --quiet
+    __omf.repo.git stash pop --quiet
 
     echo (omf::em)"Restored your changes:"(omf::off)
-    command git -C "$repo_dir" status --short --untracked-files
+    __omf.repo.git status --short --untracked-files
   end
 
-  functions -e omf.repo.git{,.stash}
   return 0
 end


### PR DESCRIPTION
The purpose of this proposal is to generate a more accurate output on `omf update`. Namely, packages which have no upstream changes now report that they are already up to date.
Since this is a proposal we haven't really discussed before, this is broken into 3 commits (instead of squashed), so it's easier to track the changes and their aims.

Regarding performance, I must admit that I did not time the new code or the old.
Overall the update process should not improve and not deteriorate in terms of performance. The previous `git pull` is broken apart to a `fetch` and a `merge`. Packages without changes skip the merge (and possibly stashing) in return for an additional check. Packages with changes pay just one more check. If `git` does any more optimizations in combining the `fetch` and `merge` when running `pull`, I am unaware of such and I would appreciate any tips.

\* Note that the bugfix is also covered by @derekstavis in **wip/reorganize-code**. I just couldn't leave it like this.