### PR TITLE
Remove PATH save/restore code

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -14,19 +14,10 @@
 #   + Source $OMF_CONFIG/init.fish
 #
 # ENV
-#   OSTYPE        Operating system.
-#   ORIGINAL_PATH Original $PATH preseved across Oh My Fish reloads.
 #   OMF_PATH      ~/.local/share/omf by default.
 #   OMF_IGNORE    List of packages to ignore.
 #   OMF_CONFIG    ~/.config/omf by default.
 #   OMF_VERSION   Oh My Fish! version
-
-# Save PATH before oh my fish for reseting the PATH when we reload OMF.
-if set -q ORIGINAL_PATH
-  set PATH $ORIGINAL_PATH
-else
-  set -gx ORIGINAL_PATH $PATH
-end
 
 # Set OMF_CONFIG if not set.
 if not set -q OMF_CONFIG


### PR DESCRIPTION
Fixes #186 by removing the PATH save/restore code from init.fish.

There isn't a single occurence where Oh My Fish code changes the
value of PATH variable.

Plugin code which changes the PATH variable should be aware of
the side-effects and manage PATHs correctly, avoiding duplication.