### PR TITLE
[generate-themes-doc.fish] Ignore '.git' suffix on theme URLs

### DIFF
--- a/tools/generate-themes-doc.fish
+++ b/tools/generate-themes-doc.fish
@@ -35,9 +35,9 @@ echo "Generating Themes documentation to $theme_doc ..."
 echo "# Available themes" > $temp_theme_toc
 
 for theme in (command find $project_dir/db/themes/ -type f|sort)
-  set -l name (echo $theme|xargs basename)
+  set -l name (basename $theme)
   set -l url (cat $theme)
-  set -l raw_content (echo $url|sed -r 's#https://github.com/([-.a-z0-9]+)/([-.a-z0-9]+)#https://raw.githubusercontent.com/\1/\2/master#gi')
+  set -l raw_content (echo $url|sed -r 's#https://github.com/([-.a-z0-9]+)/([-.a-z0-9]+)#https://raw.githubusercontent.com/\1/\2/master#gi' | sed 's#\.git/#/#gi')
   set -l readme (__find_readme $raw_content)
 
   echo "- [$name](#$name)" >> $temp_theme_toc


### PR DESCRIPTION
Currently [generate-themes-doc](/oh-my-fish/oh-my-fish/blob/master/tools/generate-themes-doc.fish) fails to fetch the **README.md** file for themes that have the '.git' suffix in their database URL.

A simple `sed` replace solves this issue.
