### PR TITLE
bugfix: git_ahead no longer reports 'none' as 'ahead'

### DIFF
--- a/lib/git/git_ahead.fish
+++ b/lib/git/git_ahead.fish
@@ -7,7 +7,7 @@ function git_ahead -a ahead behind diverged none
   case ""
     # no upstream
   case "0"\t"0"
-    test -z "$ahead"; and echo "$ahead"
+    test -z "$none"; and echo "$none"
       or echo ""
   case "*"\t"0"
     test -z "$behind"; and echo "$behind"


### PR DESCRIPTION
My last PR has a bug. :astonished:
Thanks for pointing it out @bpinto @derekstavis 