### PR TITLE
Please add the `es`  theme (adjusted `Themes.md` to include description)

### DIFF
--- a/db/themes/es
+++ b/db/themes/es
@@ -1,0 +1,1 @@
+https://github.com/eugenesvk/Fish-theme-es

--- a/docs/Themes.md
+++ b/docs/Themes.md
@@ -16,6 +16,7 @@
 - [default](#default)
 - [eclm](#eclm)
 - [edan](#edan)
+- [es](#es)
 - [fishface](#fishface)
 - [fishy-drupal](#fishy-drupal)
 - [fisk](#fisk)
@@ -1005,6 +1006,55 @@ Inspired by idan, a functional, uncluttered fish theme with usability perks for 
 ###### Font
 
 Check out [Anonymous Pro](http://www.marksimonson.com/fonts/view/anonymous-pro).
+
+
+# es
+<img src="https://cdn.rawgit.com/oh-my-fish/oh-my-fish/e4f1c2e0219a17e2c748b824004c8d0b38055c16/docs/logo.svg" align="left" width="144px" height="144px"/>
+
+#### es theme
+> A Powerline-style, Git-aware theme for [Oh My Fish][omf-link].
+
+[![MIT License](https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square)](/LICENSE) [![Fish Shell Version](https://img.shields.io/badge/fish-v2.2.0-007EC7.svg?style=flat-square)](http://fishshell.com) [![Oh My Fish Framework](https://img.shields.io/badge/Oh%20My%20Fish-Framework-007EC7.svg?style=flat-square)](https://www.github.com/oh-my-fish/oh-my-fish)
+
+<br/>
+
+## Install
+Make sure you have [Oh My Fish][omf-link] installed. Then just
+```fish
+$ omf install es
+```
+
+## Features
+
+* Git-aware theme with detailed __Git status__ in the left prompt (added, removed, modified, renamed, unstaged, stashed)
+* __Node/Python/Ruby@gemset__ current version inside a git folder in the right prompt if respective virtual environment manager is installed (nvm, pyenv, rbenv)
+* __Error status__ and __duration of last command__ in the right prompt
+* Mac-notifications on completion of long commands (10+&nbsp;seconds by default) if terminal is out of focus
+* Limits path to __two last folders__ for better visibility, with `$HOME` directory abbreviated to `~`
+* Powerline-patched fonts required
+
+## Screenshot
+
+###__Git folder__
+<p align="center">
+<img src="https://github.com/eugenesvk/Settings-Fish/blob/master/Assets/Fish%20Prompt%20Git-es.png?raw=true">
+</p>
+
+###__Normal folder (no Git)__
+<p align="center">
+<img src="https://github.com/eugenesvk/Settings-Fish/blob/master/Assets/Fish%20Prompt%20NoGit-es.png?raw=true">
+</p>
+
+# License
+
+[MIT][mit] © [eugenesvk][author]
+
+
+[mit]:            http://opensource.org/licenses/MIT
+[author]:         http://github.com/eugenesvk
+[omf-link]:       https://www.github.com/oh-my-fish/oh-my-fish
+
+[license-badge]:  https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square
 
 
 # fishface


### PR DESCRIPTION
Had to manually adjust `Themes.md` because the `generate-themes-doc.fish` was useless — instead of adding my `README.md` it emptied the whole file because it was unable to download any of the `README.md` files even from existing themes.
Also, the use of this tool is not documented at all, I had to search for previous commits to understand it exists (was just puzzled that the only thing committed was a new `db/themes/es` file, so went on to search how others committed their themes and found out about this tool — which, alas, didn't work :(