### PR TITLE
init: rewrite init process

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Apply a theme. To list available themes, type `omf theme`. You can also [preview
 
 Remove a theme or package.
 
-> Packages subscribed to `uninstall_<pkg>` events are notified before the package is removed, so custom cleanup of resources can be done. See [Uninstall](/docs/en-US/Packages.md#uninstall) for more information.
+> Packages can use uninstall hooks, so custom cleanup of resources can be done when uninstalling it. See [Uninstall](/docs/en-US/Packages.md#uninstall) for more information.
 
 #### `omf reload`
 
@@ -125,7 +125,7 @@ Every time a package/theme is installed or removed, the `bundle` file is updated
 
 ## Creating Packages
 
-Oh My Fish uses an advanced and well defined plugin architecture to ease plugin development, including init/uninstall events and function autoloading. [See the documentation](docs/en-US/Packages.md) for more details.
+Oh My Fish uses an advanced and well defined plugin architecture to ease plugin development, including init/uninstall hooks, function and completion autoloading. [See the packages documentation](docs/en-US/Packages.md) for more details.
 
 [fishshell]: http://fishshell.com
 

--- a/docs/en-US/Packages.md
+++ b/docs/en-US/Packages.md
@@ -53,24 +53,27 @@ Packages were designed to take advantages of fish events. There are currently tw
 
 ## Initialization
 
-If you want to be [notified](http://fishshell.com/docs/current/commands.html#emit) when your package loads, declare the following function in your `hello_world.fish`:
+If you want code to be executed when the package loads, you can add code to `init.fish` file at package's root directory:
 
 ```fish
-function init -a path --on-event init_hello_world
-  echo "hello_world initialized"
-end
+echo "hello_world initialized"
 ```
 
-Use this event to modify the environment, load resources, autoload functions, etc. If your package does not export any functions, you can still use this event to add functionality to your package.
+Inside this hook runs you can access three package-related variables:
+
+* `$package`: Package name
+* `$path`: Package installation path
+* `$dependencies` : Package dependencies
+
+Use this hook to modify the environment, load resources, autoload functions, etc. If your package does not export any function, you can still use this event to add functionality to your package, or dynamically create functions.
 
 ## Uninstall
 
-Oh My Fish emits `uninstall_<pkg>` events before a package is removed via `omf remove <pkg>`. Subscribers can use the event to clean up custom resources, etc.
+Oh My Fish also features `uninstall.fish` hook, which is called before a package is removed via `omf remove <pkg>`. Packages can use this hook to clean up custom resources, etc.
 
-```fish
-function uninstall --on-event uninstall_hello_world
-end
-```
+Inside this hook you can access one package-related variable:
+
+* `$path`: Package installation path
 
 
 # Make it public

--- a/docs/zh-CN/Packages.md
+++ b/docs/zh-CN/Packages.md
@@ -54,24 +54,26 @@ end
 
 ## 初始化
 
-如果你想在插件被加载时收到[通知](http://fishshell.com/docs/current/commands.html#emit)，你可以在 `hello_world.fish` 添加下面的代码：
+如果要执行的代码包时加载，可以为`init.fish`文件在包的根目录下添加代码：
 
 ```fish
-function init -a path --on-event init_hello_world
-  echo "hello_world initialized"
-end
+echo "hello_world initialized"
 ```
 
-该事件可以用于修改环境变量、加载资源和自动加载函数等。如果你的插件没有输出任何的函数，你仍然可以使用该事件加载其他的函数。
+这里面挂机运行，您可以访问包相关的变量：
+
+* `$package`：包名称
+* `$path`：软件包的安装路径
+* `$dependencies`：软件包依赖
+
+使用这个钩子来修改环境，资源负载，自动加载的功能，等等。如果你的包不出口任何功能，您仍可以使用此事件将功能添加到您的包，还是动态创建功能。
 
 ## 卸载
 
-Oh My Fish 通过 `omf remove <pkg>` 移除已安装的插件前会发送 `uninstall_<pkg>` 事件。订阅者可以使用该事件清理自定义的资源等操作。
+哦，我的鱼还设有`uninstall.fish`挂钩，通过 `omf remove <pkg>`被删除软件包之前被调用。包可以使用这个钩子清理自定义的资源，等等。
 
-```fish
-function uninstall --on-event uninstall_hello_world
-end
-```
+本书中，你可以访问一个包相关的变量：
+* `$path`：软件包的安装路径
 
 
 # 发布插件

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -56,8 +56,7 @@ Oh My Fish 自带的辅助命令工具 `omf` 可以帮助你快速获取安装�
 
 移除主题或插件。
 
-> 插件如果注册(subscribed)过 `uninstall_<pkg>` 事件将会在插件移除前触发，因此你可以自定义自身清理和扫尾的工作以保证插件干净移除。
-详见[卸载部分](Packages.md#uninstall)获取更多信息。
+> 包可以使用卸载挂钩，所以资源的自定义清理可以做到卸载时。有关更多信息，请参见 [卸载](Packages.md#uninstall) 。
 
 #### `omf new pkg | theme` _`<name>`_
 

--- a/pkg/omf/init.fish
+++ b/pkg/omf/init.fish
@@ -1,28 +1,26 @@
-function init -a path --on-event init_omf
-  set -g OMF_MISSING_ARG   1
-  set -g OMF_UNKNOWN_OPT   2
-  set -g OMF_INVALID_ARG   3
-  set -g OMF_UNKNOWN_ERR   4
+set -g OMF_MISSING_ARG   1
+set -g OMF_UNKNOWN_OPT   2
+set -g OMF_INVALID_ARG   3
+set -g OMF_UNKNOWN_ERR   4
 
-  function omf::em
-    set_color $fish_color_match ^/dev/null; or set_color cyan
-  end
-
-  function omf::dim
-    set_color $fish_color_autosuggestion ^/dev/null; or set_color 555
-  end
-
-  function omf::err
-    set_color $fish_color_error ^/dev/null; or set_color red --bold
-  end
-
-  function omf::under
-    set_color --underline
-  end
-
-  function omf::off
-    set_color normal
-  end
-
-  autoload $path/functions/{compat,core,packages,themes,bundle,util,repo,cli,search}
+function omf::em
+  set_color $fish_color_match ^/dev/null; or set_color cyan
 end
+
+function omf::dim
+  set_color $fish_color_autosuggestion ^/dev/null; or set_color 555
+end
+
+function omf::err
+  set_color $fish_color_error ^/dev/null; or set_color red --bold
+end
+
+function omf::under
+  set_color --underline
+end
+
+function omf::off
+  set_color normal
+end
+
+autoload $path/functions/{compat,core,packages,themes,bundle,util,repo,cli}

--- a/pkg/omf/templates/pkg/completions/{{NAME}}.fish
+++ b/pkg/omf/templates/pkg/completions/{{NAME}}.fish
@@ -1,1 +1,7 @@
-# See → fishshell.com/docs/current/commands.html#complete
+# Always provide completions for command line utilities.
+#
+# Check Fish documentation about completions:
+# http://fishshell.com/docs/current/commands.html#complete
+#
+# If your package doesn't provide any command line utility,
+# feel free to remove completions directory from the project.

--- a/pkg/omf/templates/pkg/functions/{{NAME}}.fish
+++ b/pkg/omf/templates/pkg/functions/{{NAME}}.fish
@@ -1,10 +1,3 @@
-# SYNOPSIS
-#   {{NAME}} [options]
-#
-# USAGE
-#   Options
-#
-
 function {{NAME}} -d "My package"
+  # Package entry-point
 end
-

--- a/pkg/omf/templates/pkg/init.fish
+++ b/pkg/omf/templates/pkg/init.fish
@@ -1,3 +1,6 @@
-function init -a path --on-event init_{{NAME}}
-end
-
+# {{NAME}} initialization hook
+#
+# You can use the following variables in this file:
+# * $package       package name
+# * $path          package path
+# * $dependencies  package dependencies

--- a/pkg/omf/templates/pkg/uninstall.fish
+++ b/pkg/omf/templates/pkg/uninstall.fish
@@ -1,3 +1,4 @@
-function uninstall --on-event uninstall_{{NAME}}
-end
-
+# {{NAME}} uninstall hook
+#
+# You can use this file to do custom cleanup when the package is uninstalled.
+# You can use the variable $path to access the package path.

--- a/pkg/omf/templates/themes/fish_greeting.fish
+++ b/pkg/omf/templates/themes/fish_greeting.fish
@@ -1,12 +1,3 @@
-# Set global color styles, for example:
-#
-# function {{NAME}}_error
-#   set_color -o red
-# end
-#
-# function {{NAME}}_normal
-#   set_color normal
-#
-
 function fish_greeting
+  # Customize fish greeting message
 end

--- a/pkg/omf/templates/themes/fish_prompt.fish
+++ b/pkg/omf/templates/themes/fish_prompt.fish
@@ -1,4 +1,3 @@
 function fish_prompt
-  set -l code $status
-  prompt_pwd
+  # Customize fish prompt
 end

--- a/pkg/omf/templates/themes/fish_right_prompt.fish
+++ b/pkg/omf/templates/themes/fish_right_prompt.fish
@@ -1,3 +1,3 @@
 function fish_right_prompt
-  set -l code $status
+  # Customize the right prompt
 end

--- a/pkg/omf/templates/themes/fish_title.fish
+++ b/pkg/omf/templates/themes/fish_title.fish
@@ -1,3 +1,3 @@
 function fish_title
-# Customize the title bar of the terminal window.
+  # Customize terminal window title
 end


### PR DESCRIPTION
Now use pure globbing to generate 100% valid function and
completion paths, effectively splitting the init process in two
steps, one which paths are added, and other when initialization
is done (sourcing init).

This initialization code introduces a new interface for
`init.fish` hook, which deprecates the previously used event
model. The new interface injects three variables into `init.fish`:
path, package and bundle. This variables can be used by the
package to autoload paths, use bundled files, etc.

Also supports key bindings by sourcing
$OMF_CONFIG/key_bindings.fish and also key_bindings.fish in
packages (plugins and themes) root directories. This is done
when fish_user_key_bindings is called.