### PR TITLE
autoload: refactor for conformance and performance

### DIFF
--- a/lib/autoload.fish
+++ b/lib/autoload.fish
@@ -1,58 +1,52 @@
-# SYNOPSIS
-#   autoload <path>...
-#   autoload -e <path>...
-#
-# OVERVIEW
-#   Manipulate autoloading path components.
-#
-#   If called without options, the paths passed as arguments are added to
-#   $fish_function_path. All paths ending with `completions` are correctly
-#   added to $fish_complete_path. Returns 0 if one or more paths exist. If all
-#   paths are missing, returns != 0.
-#
-#   When called with -e, the paths passed as arguments are removed from
-#   $fish_function_path. All arguments ending with `completions` are correctly
-#   removed from $fish_complete_path. Returns 0 if one or more paths erased. If
-#   no paths were erased, returns != 0.
-
-function autoload -d "Manipulate autoloading path components"
-  set -l paths $argv
-
+function autoload
   switch "$argv[1]"
   case '-e' '--erase'
-    set erase
-
-    if test (count $argv) -ge 2
-      set paths $argv[2..-1]
-    else
-      echo "usage: autoload $argv[1] <path>..." 1>&2
-      return 1
-    end
+    test (count $argv) -ge 2
+      and __autoload_erase $argv[2..-1]
+      or echo "usage: autoload $argv[1] <path>..." 1>&2
   case "-*" "--*"
     echo "autoload: invalid option $argv[1]"
     return 1
+  case '*'
+    test (count $argv) -ge 1
+      and __autoload_insert $argv
+      or echo "usage: autoload <path>..." 1>&2
   end
-
-  for path in $paths
-    not test -d "$path"; and continue
-
-    set -l dest fish_function_path
-
-    if test (basename "$path") = completions
-      set dest fish_complete_path
-    end
-
-    if set -q erase
-      if set -l index (contains -i -- $path $$dest)
-        set -e {$dest}[$index]
-        set return_success
-      end
-    else
-      set return_success
-      contains -- "$path" $$dest; and continue
-      set $dest "$path" $$dest
-    end
-  end
-
-  set -q return_success
 end
+function __autoload_insert
+  set -l function_path
+  set -l complete_path
+  for path in $argv
+    not test -d "$path"; and continue
+    set -l IFS '/'
+    echo $path | read -la components
+    if test "x$components[-1]" = xcompletions
+      contains -- $path $fish_complete_path
+        or set complete_path $complete_path $path
+    else
+      contains -- $path $fish_function_path
+        or set function_path $function_path $path
+    end;
+  end;
+  test -n "$function_path"
+    and set fish_function_path $fish_function_path[1] $function_path $fish_function_path[2..-1]
+  test -n "$complete_path"
+    and set fish_complete_path $fish_complete_path[1] $complete_path $fish_complete_path[2..-1]
+  return 0
+end;
+function __autoload_erase
+  set -l function_indexes
+  set -l complete_indexes
+  for path in $argv
+    set -l IFS '/'
+    echo $path | read -la components
+    test "x$components[-1]" = xcompletions
+      and set complete_indexes $complete_indexes (contains -i $path $fish_complete_path)
+      or  set function_indexes $function_indexes (contains -i $path $fish_function_path)
+  end;
+  test -n "$function_indexes"
+    and set -e fish_function_path[$function_indexes]
+  test -n "$complete_indexes"
+    and set -e fish_complete_path[$complete_indexes]
+  return 0
+end;


### PR DESCRIPTION
Refactor autoload: Split the big function into two smaller ones,
doing only option parsing at main function.

The algorithm is also rewritten, now in two steps for both path
inclusion an exclusion functions: 1) use auxiliary lists to store
valid function and completion paths, 2) bulk insert or remove just
once in the variable.

Now also respects path insertion policy, keeping user function
path always in front of other paths, thus allowing precedence of
user functions.