### PR TITLE
registry: remove deprecated agnoster-mercurial theme

### DIFF
--- a/db/themes/agnoster-mercurial
+++ b/db/themes/agnoster-mercurial
@@ -1,1 +1,0 @@
-https://github.com/oh-my-fish/theme-agnoster-mercurial


### PR DESCRIPTION
This theme is deprecated, as mercurial support have been merged into `agnoster`.