### PR TITLE
Update plugin URLs and remove broken plugin entries

### DIFF
--- a/db/pkg/ansible
+++ b/db/pkg/ansible
@@ -1,1 +1,1 @@
-https://github.com/wa/pkg-ansible
+https://github.com/pkg-gretel/pkg-ansible

--- a/db/pkg/copy
+++ b/db/pkg/copy
@@ -1,1 +1,0 @@
-https://github.com/wa/pkg-copy

--- a/db/pkg/direnv
+++ b/db/pkg/direnv
@@ -1,1 +1,1 @@
-https://github.com/wa/pkg-direnv
+https://github.com/pkg-gretel/pkg-direnv

--- a/db/pkg/extract
+++ b/db/pkg/extract
@@ -1,1 +1,1 @@
-https://github.com/wa/pkg-extract
+https://github.com/pkg-gretel/pkg-extract

--- a/db/pkg/gi
+++ b/db/pkg/gi
@@ -1,1 +1,1 @@
-https://github.com/wa/pkg-gi
+https://github.com/fishery/gi

--- a/db/pkg/hub
+++ b/db/pkg/hub
@@ -1,1 +1,1 @@
-https://github.com/wa/pkg-hub
+https://github.com/pkg-gretel/pkg-hub

--- a/db/pkg/iex
+++ b/db/pkg/iex
@@ -1,1 +1,1 @@
-https://github.com/belltoy/plugin-iex.git
+https://github.com/belltoy/plugin-iex

--- a/db/pkg/keychain
+++ b/db/pkg/keychain
@@ -1,1 +1,1 @@
-https://github.com/wa/pkg-keychain
+https://github.com/pkg-gretel/pkg-keychain

--- a/db/pkg/limap
+++ b/db/pkg/limap
@@ -1,1 +1,0 @@
-https://github.com/wa/pkg-limap

--- a/db/pkg/mix
+++ b/db/pkg/mix
@@ -1,1 +1,1 @@
-https://github.com/belltoy/plugin-mix.git
+https://github.com/belltoy/plugin-mix

--- a/db/pkg/osx_manpath
+++ b/db/pkg/osx_manpath
@@ -1,1 +1,0 @@
-https://github.com/wa/pkg-osx_manpath

--- a/db/pkg/peco
+++ b/db/pkg/peco
@@ -1,1 +1,1 @@
-https://github.com/wa/pkg-peco
+https://github.com/pkg-gretel/pkg-peco

--- a/db/pkg/pyenv
+++ b/db/pkg/pyenv
@@ -1,1 +1,0 @@
-https://github.com/wa/pkg-pyenv

--- a/db/pkg/set_color
+++ b/db/pkg/set_color
@@ -1,1 +1,0 @@
-https://github.com/wa/pkg-set_color

--- a/db/pkg/stamp
+++ b/db/pkg/stamp
@@ -1,1 +1,0 @@
-https://github.com/wa/pkg-stamp

--- a/db/pkg/tiny
+++ b/db/pkg/tiny
@@ -1,1 +1,1 @@
-https://github.com/wa/pkg-tiny
+https://github.com/fishery/tiny

--- a/db/pkg/title
+++ b/db/pkg/title
@@ -1,1 +1,1 @@
-https://github.com/oh-my-fish/plugin-title.git
+https://github.com/oh-my-fish/plugin-title

--- a/db/pkg/vcs
+++ b/db/pkg/vcs
@@ -1,1 +1,1 @@
-https://github.com/oh-my-fish/plugin-vcs.git
+https://github.com/oh-my-fish/plugin-vcs

--- a/db/pkg/z
+++ b/db/pkg/z
@@ -1,1 +1,1 @@
-https://github.com/oh-my-fish/pkg-z
+https://github.com/oh-my-fish/plugin-z

--- a/db/themes/flash
+++ b/db/themes/flash
@@ -1,1 +1,1 @@
-https://github.com/wa/theme-flash
+https://github.com/fishery/flash

--- a/db/themes/hogan
+++ b/db/themes/hogan
@@ -1,1 +1,0 @@
-https://github.com/wa/theme-hogan

--- a/db/themes/hulk
+++ b/db/themes/hulk
@@ -1,1 +1,1 @@
-https://github.com/wa/theme-hulk
+https://github.com/fishery/hulk

--- a/db/themes/led
+++ b/db/themes/led
@@ -1,1 +1,0 @@
-https://github.com/wa/theme-led

--- a/db/themes/lolfish
+++ b/db/themes/lolfish
@@ -1,1 +1,1 @@
-https://github.com/er0/lolfish.git
+https://github.com/er0/lolfish

--- a/db/themes/russell
+++ b/db/themes/russell
@@ -1,1 +1,0 @@
-https://github.com/wa/theme-russell


### PR DESCRIPTION
A number of plugins in the package database have moved repository locations, or have simply been deleted. This PR updates the URLs of any plugins to their new GitHub locations, and removes entries to plugins that are no longer available.