### PR TITLE
Implement safe shell reloading inside omf plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Remove a theme or package.
 
 > Packages subscribed to `uninstall_<pkg>` events are notified before the package is removed, so custom cleanup of resources can be done. See [Uninstall](/docs/en-US/Packages.md#uninstall) for more information.
 
+#### `omf reload`
+
+Reload Oh My Fish and all plugins by using `exec` to replace current shell process with a brand new.
+
+> This command try to be as safe as possible, mitigating side-effects caused by `exec` and preventing the reload in case of background processes.
+
 #### `omf new pkg | theme` _`<name>`_
 
 Scaffold out a new package or theme.

--- a/pkg/omf/functions/cli/omf.cli.reload.fish
+++ b/pkg/omf/functions/cli/omf.cli.reload.fish
@@ -1,0 +1,18 @@
+function omf.cli.reload
+  if not contains -- --force $argv
+    if count (jobs) >/dev/null ^&1
+      __omf.cli.reload.job_warning
+      return 1
+    end
+  end
+  omf.reload
+end
+
+function __omf.cli.reload.job_warning
+  echo (set_color -u)"Reload aborted. There are background jobs:"(set_color normal)
+  echo
+  jobs
+  echo
+  echo "For your safety, finish all background jobs before reloading Oh My Fish."
+  echo "If you are absolutely sure of what you are doing, you can bypass this check using --force."
+end

--- a/pkg/omf/functions/cli/omf.cli.remove.fish
+++ b/pkg/omf/functions/cli/omf.cli.remove.fish
@@ -7,6 +7,9 @@ function omf.cli.remove -a name
     switch $code
     case 0
       echo (omf::em)"$name successfully removed."(omf::off)
+      # Opt-in flag for testing
+      set -q OMF_AUTO_RELOAD
+        and omf.cli.reload
     case 1
       echo (omf::err)"$name could not be removed."(omf::off) 1^&2
     case 2

--- a/pkg/omf/functions/cli/omf.cli.update.fish
+++ b/pkg/omf/functions/cli/omf.cli.update.fish
@@ -23,4 +23,8 @@ function omf.cli.update
   for package in $packages
     omf.packages.update $package
   end
+
+  # Opt-in flag for testing
+  set -q OMF_AUTO_RELOAD
+    and omf.cli.reload
 end

--- a/pkg/omf/functions/core/omf.reload.fish
+++ b/pkg/omf/functions/core/omf.reload.fish
@@ -1,0 +1,11 @@
+function omf.reload -d "Reload fish process via exec, keeping some context"
+  set -q CI; and return 0
+
+  history --save
+  set -gx dirprev $dirprev
+  set -gx dirnext $dirnext
+  set -gx dirstack $dirstack
+  set -gx fish_greeting ''
+
+  exec fish
+end

--- a/pkg/omf/functions/omf.fish
+++ b/pkg/omf/functions/omf.fish
@@ -40,6 +40,9 @@ function omf -d "Oh My Fish"
     case "doctor"
       omf.cli.doctor
 
+    case "reload"
+      omf.cli.reload $arguments
+
     case "i" "install" "get"
       omf.cli.install $arguments
 


### PR DESCRIPTION
This commit adds an improved reload code for Oh My Fish, besides
saving the history now the reloading technique keeps directory
history and stack and clears fish_greeting, for a transparent
transition.

The reloading code is now safe regarding to background jobs. exec
wipes fish job control, so the user-facing code under the (just-
introduced by this commit) `omf reload`, and usages under
`omf remove` and `omf update` are now kept safe by a warning.

Recap of the commit:
- Add improved reload code (omf.reload)
- Add a safe reload code (omf.cli.reload)
- Add `omf reload` command