### PR TITLE
Allow selective updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,14 @@ fish install
 
 Oh My Fish includes a small utility `omf` to fetch and install new packages and themes.
 
-#### `omf update`
+#### `omf update` _`[omf]`_ _`[<package>...]`_
 
 Update the framework and installed packages.
+
+- When called without arguments, update core and all installed packages.
+- You can choose to update only the core, by running `omf update omf`.
+- For selective package update, list only the names of packages you wish to
+  update. You may still include "omf" in the list to update the core as well.
 
 #### `omf install` _`[<name>|<url>]`_
 

--- a/pkg/omf/functions/cli/omf.cli.update.fish
+++ b/pkg/omf/functions/cli/omf.cli.update.fish
@@ -1,12 +1,26 @@
 function omf.cli.update
-  if omf.core.update
-    echo (omf::em)"Oh My Fish is up to date."(omf::off)
+  set -l update_core
+  set -l packages $argv
+  if test (count $packages) -gt 0
+    # If several packages are listed, only update core if "omf" is listed among them.
+    # Also keep "omf" out of the list of packages to update.
+    set index (contains -i -- omf $packages)
+      and set -e packages[$index]
+      or set -e update_core
   else
-    echo (omf::err)"Oh My Fish failed to update."(omf::off)
-    echo "Please open a new issue here → "(omf::em)"github.com/oh-my-fish/oh-my-fish/issues"(omf::off)
+    set packages (omf.packages.list --installed)
   end
 
-  for package in (omf.packages.list --installed)
+  if set -q update_core
+    if omf.core.update
+      echo (omf::em)"Oh My Fish is up to date."(omf::off)
+    else
+      echo (omf::err)"Oh My Fish failed to update."(omf::off)
+      echo "Please open a new issue here → "(omf::em)"github.com/oh-my-fish/oh-my-fish/issues"(omf::off)
+    end
+  end
+
+  for package in $packages
     omf.packages.update $package
   end
 end

--- a/pkg/omf/functions/omf.fish
+++ b/pkg/omf/functions/omf.fish
@@ -59,7 +59,7 @@ function omf -d "Oh My Fish"
       omf.cli.theme $arguments
 
     case "u" "update"
-      omf.cli.update
+      omf.cli.update $arguments
 
     case "*"
       echo (omf::err)"$argv[1] option not recognized"(omf::off) 1^&2


### PR DESCRIPTION
Until now, `omf update` was always "all-in".
This proposal keeps the default behavior, but also let's the user choose to update only the core framework and/or some packages.

##### Usage examples:
- `omf update`: update the framework and all installed packages (default behavior)
- `omf update omf`: update the core framework only
- `omf update agnoster`: only update the agnoster theme
- `omf update balias omf agnoster`: update the core framework, the balias plugin and the agnoster theme. The core framework is always updated first, if included.