### PR TITLE
Parallel fetch on `omf update`

### DIFF
--- a/pkg/omf/functions/cli/omf.cli.update.fish
+++ b/pkg/omf/functions/cli/omf.cli.update.fish
@@ -30,9 +30,14 @@ function omf.cli.update
   omf.index.update
     or return 1
 
-  for package in $packages
-    omf.packages.update $package
+  if omf.packages.check-updates $packages
+    for package in $packages
+      omf.packages.update $package
+    end
+  else
+    echo (omf::em)"All packages are up to date."(omf::off)
   end
+
 
   # Opt-in flag for testing
   if set -q OMF_AUTO_RELOAD

--- a/pkg/omf/functions/packages/omf.packages.check-updates.fish
+++ b/pkg/omf/functions/packages/omf.packages.check-updates.fish
@@ -2,7 +2,7 @@ function omf.packages.check-updates
   set -l max_workers 8
   set -l fetch_cmd "omf.repo.fetch"
   set -l progress_indicator \u25cf
-  set -l error_log (mktemp -t omf_check-updates.log)
+  set -l error_log (mktemp -t omf_check-updates.XXXX.log)
 
   # Supress Git's attempt to find missing repositories with different credentials.
   # Git > 2.3
@@ -24,7 +24,7 @@ function omf.packages.check-updates
 
         # Error reporting here would be ugly because it clutters the display.
         # Save to log file instead.
-        fish -c "$fetch_cmd $package_path" ^$error_log &
+        fish -c "$fetch_cmd $package_path" ^^$error_log &
 
         printf "$progress_indicator"
       else
@@ -41,6 +41,6 @@ function omf.packages.check-updates
   end
   echo " done!"
 
-  test (wc -l <$error_log) -gt 0
+  test (wc -l < $error_log) -gt 0
     and echo (omf::err)"Please see "(omf::off)"$error_log"(omf::err)" for errors encountered while getting updates."(omf::off)
 end

--- a/pkg/omf/functions/packages/omf.packages.check-updates.fish
+++ b/pkg/omf/functions/packages/omf.packages.check-updates.fish
@@ -1,0 +1,46 @@
+function omf.packages.check-updates
+  set -l max_workers 8
+  set -l fetch_cmd "omf.repo.fetch"
+  set -l progress_indicator \u25cf
+  set -l error_log (mktemp -t omf_check-updates.log)
+
+  # Supress Git's attempt to find missing repositories with different credentials.
+  # Git > 2.3
+  set -lx GIT_TERMINAL_PROMPT 0
+  # hack for older Git versions
+  set -lx SSH_ASKPASS echo
+
+  function __omf.packages.active_fetches -V fetch_cmd
+    count (jobs | grep '$fetch_cmd')
+  end
+
+  printf "Getting package updates... "
+  while test (count $argv) -gt 0
+    if test (__omf.packages.active_fetches) -lt $max_workers
+      if set -l package_path (omf.packages.path $argv[1])
+        # Skip packages outside version control
+        not command git -C $package_path rev-parse --git-dir >/dev/null ^&1
+          and continue
+
+        # Error reporting here would be ugly because it clutters the display.
+        # Save to log file instead.
+        fish -c "$fetch_cmd $package_path" ^$error_log &
+
+        printf "$progress_indicator"
+      else
+        echo (omf::err)"Could not find $argv[1]"(omf::off) >&2
+      end
+      set -e argv[1]
+    end
+    sleep 0.01s
+  end
+
+  # Wait for the last jobs
+  while test (__omf.packages.active_fetches) -gt 0
+    sleep 0.01s
+  end
+  echo " done!"
+
+  test (wc -l <$error_log) -gt 0
+    and echo (omf::err)"Please see "(omf::off)"$error_log"(omf::err)" for errors encountered while getting updates."(omf::off)
+end

--- a/pkg/omf/functions/packages/omf.packages.check-updates.fish
+++ b/pkg/omf/functions/packages/omf.packages.check-updates.fish
@@ -1,7 +1,9 @@
 function omf.packages.check-updates
   set -l max_workers 8
   set -l fetch_cmd "omf.repo.fetch"
-  set -l progress_indicator \u25cf
+  set -l progress_done \u25a3
+  set -l progress_left \u25a2
+  set -l progress_boxes 40
   set -l error_log (mktemp -t omf_check-updates.XXXX.log)
 
   # Supress Git's attempt to find missing repositories with different credentials.
@@ -14,7 +16,45 @@ function omf.packages.check-updates
     count (jobs | grep '$fetch_cmd')
   end
 
-  printf "Getting package updates... "
+  function __omf.packages.string_repeat -a count str
+    # `string repeat` is new in fish v2.6
+    # for older versions, use a `printf` hack
+    string repeat -Nq -n $count $str ^/dev/null
+      or printf "$str%.0s" (seq $count)
+  end
+
+  function __omf.packages.count_boxes -a left total boxes
+    set -l done (math "$total - $left")
+    set -l done_boxes (math "$done * $boxes / $total")
+    set -l left_boxes (math "$left * $boxes / $total")
+
+    # Account for rounding issues
+    if test (math "$left_boxes + $done_boxes") -lt $boxes
+      test $done_boxes -gt $left_boxes
+        and set done_boxes (math "$done_boxes + 1")
+        or set left_boxes (math "$left_boxes + 1")
+    end
+
+    echo $done_boxes
+    echo $left_boxes
+  end
+
+  function __omf.packages.display_progress -S -a left total
+    # Carriage Return to move the cursor back to the beginning of the line.
+    echo -ne "\r"
+    # Place progress boxes
+    set -l boxes (__omf.packages.count_boxes $left $total $progress_boxes)
+    if test $boxes[1] -gt 0
+      __omf.packages.string_repeat $boxes[1] $progress_done
+    end
+    if test $boxes[2] -gt 0
+      __omf.packages.string_repeat $boxes[2] $progress_left
+    end
+  end
+
+  set -l package_count (count $argv)
+
+  echo "Getting package updates... "
   while test (count $argv) -gt 0
     if test (__omf.packages.active_fetches) -lt $max_workers
       if set -l package_path (omf.packages.path $argv[1])
@@ -26,11 +66,11 @@ function omf.packages.check-updates
         # Save to log file instead.
         fish -c "$fetch_cmd $package_path" ^^$error_log &
 
-        printf "$progress_indicator"
       else
         echo (omf::err)"Could not find $argv[1]"(omf::off) >&2
       end
       set -e argv[1]
+      __omf.packages.display_progress (count $argv) $package_count
     end
     sleep 0.01s
   end
@@ -39,7 +79,9 @@ function omf.packages.check-updates
   while test (__omf.packages.active_fetches) -gt 0
     sleep 0.01s
   end
-  echo " done!"
+  echo -ne "\r done!"
+  __omf.packages.string_repeat $progress_boxes " "  # Clear the previous boxes
+  echo
 
   test (wc -l < $error_log) -gt 0
     and echo (omf::err)"Please see "(omf::off)"$error_log"(omf::err)" for errors encountered while getting updates."(omf::off)

--- a/pkg/omf/functions/packages/omf.packages.update.fish
+++ b/pkg/omf/functions/packages/omf.packages.update.fish
@@ -6,7 +6,7 @@ function omf.packages.update -a name
 
   # Only pull packages in version control
   if test -e $target_path/.git
-    omf.repo.pull $target_path
+    omf.repo.merge $target_path
     switch $status
       case 0
         omf.bundle.install $target_path/bundle

--- a/pkg/omf/functions/repo/omf.repo.fetch.fish
+++ b/pkg/omf/functions/repo/omf.repo.fetch.fish
@@ -1,0 +1,23 @@
+function omf.repo.fetch
+  if test (count $argv) -eq 0
+    echo (omf::err)"omf.repo.fetch takes a repository path as an argument."(omf::off)
+    return $OMF_MISSING_ARG
+  end
+
+  set -l repo_dir $argv[1]
+  function __omf.repo.git -V repo_dir
+    command git -C "$repo_dir" $argv
+  end
+
+  set -l remote origin
+  if test (__omf.repo.git config --get remote.upstream.url)
+    set remote upstream
+  end
+
+  # the refspec ensures that '$remote/master' gets updated
+  set -l refspec "refs/heads/master:refs/remotes/$remote/master"
+  __omf.repo.git fetch --quiet $remote $refspec;
+    or return 1
+
+  return 0
+end

--- a/pkg/omf/functions/repo/omf.repo.merge.fish
+++ b/pkg/omf/functions/repo/omf.repo.merge.fish
@@ -1,0 +1,56 @@
+function omf.repo.merge
+  if test (count $argv) -eq 0
+    echo (omf::err)"omf.repo.merge takes a repository path as an argument."(omf::off) 1>&2
+    return $OMF_MISSING_ARG
+  end
+  set -l repo_dir $argv[1]
+
+  function __omf.repo.git -V repo_dir
+    command git -C "$repo_dir" $argv
+  end
+
+  set initial_branch (__omf.repo.git symbolic-ref -q --short HEAD);
+    or return 1
+  set initial_revision (__omf.repo.git rev-parse -q --verify HEAD);
+    or return 1
+
+  if not test (__omf.repo.git rev-parse --verify --quiet FETCH_HEAD)
+    echo "FETCH_HEAD not found. Did you fetch before trying to merge?"
+    return 1
+  end
+
+  if test (__omf.repo.git rev-list --count master...FETCH_HEAD) -eq 0
+    return 2
+  end
+
+  if not __omf.repo.git diff --quiet
+    echo (omf::em)"Stashing your changes:"(omf::off)
+    __omf.repo.git status --short --untracked-files
+    __omf.repo.git stash save --include-untracked --quiet;
+      and set stashed
+  end
+
+  if test "$initial_branch" != master
+    __omf.repo.git checkout master --quiet
+  end
+
+  if not __omf.repo.git merge --ff-only --quiet FETCH_HEAD
+    __omf.repo.git checkout $initial_branch
+    __omf.repo.git reset --hard $initial_revision
+    set -q stashed; and __omf.repo.git stash pop
+    return 1
+  end
+
+  if test "$initial_branch" != master
+    __omf.repo.git checkout $initial_branch --quiet
+  end
+
+  if set -q stashed
+    __omf.repo.git stash pop --quiet
+
+    echo (omf::em)"Restored your changes:"(omf::off)
+    __omf.repo.git status --short --untracked-files
+  end
+
+  return 0
+end

--- a/pkg/omf/functions/repo/omf.repo.pull.fish
+++ b/pkg/omf/functions/repo/omf.repo.pull.fish
@@ -1,63 +1,15 @@
 function omf.repo.pull
-
   if test (count $argv) -eq 0
     echo (omf::err)"omf.repo.pull takes a repository path as an argument."(omf::off) >&2
     return $OMF_MISSING_ARG
   end
 
-  set -l repo_dir $argv[1]
-
-  function __omf.repo.git -V repo_dir
-    command git -C "$repo_dir" $argv
+  omf.repo.fetch $argv
+  set -l fetch_status $status
+  if not test $fetch_status -eq 0
+    return $fetch_status
   end
 
-  set -l remote origin
-  if test (__omf.repo.git config --get remote.upstream.url)
-    set remote upstream
-  end
-
-  set initial_branch (__omf.repo.git symbolic-ref -q --short HEAD);
-    or return 1
-  set initial_revision (__omf.repo.git rev-parse -q --verify HEAD);
-    or return 1
-
-  # the refspec ensures that '$remote/master' gets updated
-  set -l refspec "refs/heads/master:refs/remotes/$remote/master"
-  __omf.repo.git fetch --quiet $remote $refspec;
-    or return 1
-
-  if test (__omf.repo.git rev-list --count master...FETCH_HEAD) -eq 0
-    return 2
-  end
-
-  if not __omf.repo.git diff --quiet
-    echo (omf::em)"Stashing your changes:"(omf::off)
-    __omf.repo.git status --short --untracked-files
-    __omf.repo.git stash save --include-untracked --quiet;
-      and set stashed
-  end
-
-  if test "$initial_branch" != master
-    __omf.repo.git checkout master --quiet
-  end
-
-  if not __omf.repo.git merge --ff-only --quiet FETCH_HEAD
-    __omf.repo.git checkout $initial_branch
-    __omf.repo.git reset --hard $initial_revision
-    set -q stashed; and __omf.repo.git stash pop
-    return 1
-  end
-
-  if test "$initial_branch" != master
-    __omf.repo.git checkout $initial_branch --quiet
-  end
-
-  if set -q stashed
-    __omf.repo.git stash pop --quiet
-
-    echo (omf::em)"Restored your changes:"(omf::off)
-    __omf.repo.git status --short --untracked-files
-  end
-
-  return 0
+  omf.repo.merge $argv
+  return $status
 end


### PR DESCRIPTION
The current `omf update` process is somewhat slow, and becomes even more slow with each new installed package. The immediate suspects are the sequential `git fetch`s that are done for each and every installed package.

Based on the following assumptions:
- A single `git fetch` instance is not too CPU or Disk I/O intensive to exclude other instances from running in parallel.
- Each `git fetch` instance is slowed down a lot more by network overhead (DNS resolve, TCP handshake, session encryption) than by CPU and I/O operations.
- Each `git fetch` instance in the `omf update` process works on a different and independent directory on the file-system.
- It is reasonable to defer status reports for each package -- until the merge phase, in favor of a more simple implementation.

The `fetch` phase seems like an excellent candidate for concurrent execution.
Running several `git fetch` instances in parallel might benefit from concurrent execution on multiple threads/cores, and most importantly from the option to keep working while a single instance opens a connection to github's servers
Eventually these advantages reduce the total time required to perform an `omf update`.

_Performance_:
1. Cursory benchmarks, tested by updating core and 40 installed plugins and themes, all already up to date.
   `time -p fish -ic "omf.cli.update"`
   - Without the proposed changes (HEAD at fb004f8)
     real **40.65**
     user **4.02**
     sys **5.25**
     (You can see that this process is not CPU-bound. Something else wastes most of the time)
   - With the proposed changes (branch [parallel-fetch](https://github.com/oranja/oh-my-fish/commits/parallel-fetch))
     real **10.41**
     user **11.63**
     sys **8.41**
     (You can see that multiple cores are actually used: `real` < `user`+`sys` -by a large margin.)
   
   Overall, the process is 4 times faster on my machine with the proposed changes.
2. Updating a single package _vs._ updating two packages.
   - With the proposed changes (branch [parallel-fetch](https://github.com/oranja/oh-my-fish/commits/parallel-fetch), including the changes from #268)
     - `time -p fish -ic "omf.cli.update balias"`
       real **1.39**
       user **0.51**
       sys **0.51**
     - `time -p fish -ic "omf.cli.update balias agnoster"`
       real **1.46**
       user **0.72**
       sys **0.74**
   
   Adding another package to the queue only increased the total run-time by 5%.
   - Without the proposed changes (HEAD at fb004f8)
     - `time -p fish -ic "omf.packages.update balias"`, without the proposed changes.
       real **1.19**
       user **0.25**
       sys **0.23**
     - `time -p fish -ic "omf.packages.update balias; omf.packages.update agnoster"`, without the proposed changes.
       real **2.21**
       user **0.38**
       sys **0.35**
   
   A simple check without the proposed changes showed an 85% increase (1.19 real for 1 vs. 2.21 real for 2).
3. There is an evident drawback to this change, however. The proposed `update` procedure relies on busy-wait loops which loads the system even more than the actual operation.

_Testing_: This has been tested on my 5-year-old dual-core i7 laptop, running Fedora 23 x64 and fish v2.2.0. Help testing this for functionality and performance on OS X and any other platform will be very welcome.

_Note_: This PR relies heavily on PRs #220 and to a little extent on #268.
Since they both received no objections so far, I allowed myself to assume that they will be accepted soon, and use them as the base for this PR.

_Possible future improvement_: Provide more detailed progress information in the fetch phase.
It's easy to get simple progress information by tracking `$argv` while it's getting shorter. I chose to skip this enhancement at this time because of personal time constraints, and because I prefer the main functionality changes to get proper attention first.
