### PR TITLE
registry: point direnv plugin to organization's version

### DIFF
--- a/db/pkg/direnv
+++ b/db/pkg/direnv
@@ -1,1 +1,1 @@
-https://github.com/pkg-gretel/pkg-direnv
+https://github.com/oh-my-fish/plugin-direnv


### PR DESCRIPTION
This is a brand new plugin following the best conventions and open to expansion.