### PR TITLE
`omf doctor` checks for fish & git versions

### DIFF
--- a/pkg/omf/functions/core/omf.doctor.fish
+++ b/pkg/omf/functions/core/omf.doctor.fish
@@ -3,7 +3,6 @@ function __omf.doctor.theme
     echo (omf::err)"Warning: "(omf::off)(omf::em)"fish_prompt.fish"(omf::off)" is overridden."
     echo (omf::em)"  fish_config"(omf::off)" command persists the prompt to "(omf::em)"~/.config/fish/functions/fish_prompt.fish"(omf::off)
     echo "  That file takes precedence over Oh My Fish's themes. Remove the file to fix it:"
-
     echo (omf::em)"  rm ~/.config/fish/functions/fish_prompt.fish"(omf::off)
     echo
 
@@ -13,7 +12,42 @@ function __omf.doctor.theme
   return 0
 end
 
+function __omf.doctor.fish_version
+  set -l min_version 2.2.0
+  set -l current_version
+  begin
+    set -l IFS '-'
+    echo $FISH_VERSION | read -la version_parts
+    set current_version "$version_parts[1]"
+  end
+
+  if not omf.check.version $min_version $current_version
+    echo (omf::err)"Warning: "(omf::off)"Oh-My-Fish requires "(omf::em)"fish"(omf::off)" version "(omf::em)"$min_version"(omf::off)" or above"
+    echo "Your fish version is "(omf::em)$FISH_VERSION(omf::off)
+    echo
+    return 1
+  end
+end
+
+function __omf.doctor.git_version
+  set -l min_version 1.9.5
+  set -l current_version
+  begin
+    git --version | read -la version_parts
+    set current_version "$version_parts[3]"
+  end
+
+  if not omf.check.version $min_version $current_version
+    echo (omf::err)"Warning: "(omf::off)"Oh-My-Fish requires "(omf::em)"git"(omf::off)" version "(omf::em)"$min_version"(omf::off)" or above"
+    echo "Your git version is "(omf::em)$current_version(omf::off)
+    echo
+    return 1
+  end
+end
+
 function omf.doctor
+  __omf.doctor.fish_version; or set -l doctor_failed
+  __omf.doctor.git_version; or set -l doctor_failed
   __omf.doctor.theme; or set -l doctor_failed
 
   if set -q doctor_failed

--- a/pkg/omf/functions/util/omf.check.version.fish
+++ b/pkg/omf/functions/util/omf.check.version.fish
@@ -1,0 +1,3 @@
+function omf.check.version -a min_version -a current_version
+  test (echo "$min_version"\n"$current_version" | tr '.' ' ' | sort -n | head -n1) = (echo "$min_version" | tr '.' ' ')
+end


### PR DESCRIPTION
Minimum *fish* version: *2.2.0*
* OMF uses `function -V` (`--inherit-variable`) in omf.repo

Minimum *git* version: *1.9.5*
* OMF uses `git -C` in omf.repo
* OMF uses `git --depth 1` in installer
* OMF intends to use `git --depth 1` for package install