### PR TITLE
lib: deprecate `available` function

### DIFF
--- a/lib/available.fish
+++ b/lib/available.fish
@@ -1,9 +1,0 @@
-# SYNOPSIS
-#   available [name]
-#
-# OVERVIEW
-#   Check if a function or program is available.
-
-function available -a name -d "Check if a function or program is available."
-  type "$name" ^/dev/null >&2
-end

--- a/pkg/omf/functions/compat/available.fish
+++ b/pkg/omf/functions/compat/available.fish
@@ -1,0 +1,10 @@
+function available
+  echo (status -t)[5] | read -la caller
+  printf 'warning: function %savailable%s is deprecated and will be removed soon.\n' \
+  (set_color -u) (set_color normal)
+
+  contains input $caller
+    or echo $caller
+
+  type -q $argv
+end


### PR DESCRIPTION
This PR officially marks available as deprecated, moving the
deprecated functionality to omf plugin compat quarantine directory.