### PR TITLE
bugfix: Core update reported failure when up-to-date

### DIFF
--- a/pkg/omf/functions/cli/omf.cli.update.fish
+++ b/pkg/omf/functions/cli/omf.cli.update.fish
@@ -12,7 +12,8 @@ function omf.cli.update
   end
 
   if set -q update_core
-    if omf.core.update
+    omf.core.update
+    if test $status -ne 1
       echo (omf::em)"Oh My Fish is up to date."(omf::off)
     else
       echo (omf::err)"Oh My Fish failed to update."(omf::off)


### PR DESCRIPTION
Due to an oversight in my PR #285, OMF core update reports failure whenever the core is already at the latest revision. This is a simple bugfix for immediate resolution.

As further improvement it's possible to differentiate "updated just now" from "was already up to date" message, but it's not urgent by any means.