### PR TITLE
Fixed links in the english docs.

### DIFF
--- a/docs/en-US/FAQ.md
+++ b/docs/en-US/FAQ.md
@@ -8,8 +8,8 @@
 
 <p align="center">
   <b>English</b> &bull;
-  <a href="docs/zh-CN/FAQ.md">简体中文</a> &bull;
-  <a href="docs/ru-RU/FAQ.md">Русский</a>
+  <a href="../zh-CN/FAQ.md">简体中文</a> &bull;
+  <a href="../ru-RU/FAQ.md">Русский</a>
 </p>
 
 

--- a/docs/en-US/Packages.md
+++ b/docs/en-US/Packages.md
@@ -8,8 +8,8 @@
 
 <p align="center">
   <b>English</b> &bull;
-  <a href="docs/zh-CN/Packages.md">简体中文</a> &bull;
-  <a href="docs/ru-RU/Packages.md">Русский</a>
+  <a href="../zh-CN/Packages.md">简体中文</a> &bull;
+  <a href="../ru-RU/Packages.md">Русский</a>
 </p>
 
 # Creating


### PR DESCRIPTION
There were broken links to the translated docs.

I have changed `docs/` to `../`, now it's fine.