### PR TITLE
Add plugin to grep error messages

### DIFF
--- a/db/pkg/errno-grep
+++ b/db/pkg/errno-grep
@@ -1,1 +1,1 @@
-.../errno-grep.git
+https://github.com/Shadowigor/plugin-errno-grep.git

--- a/db/pkg/errno-grep
+++ b/db/pkg/errno-grep
@@ -1,0 +1,1 @@
+.../errno-grep.git


### PR DESCRIPTION
Inspired by [plugin-errno](https://github.com/oh-my-fish/plugin-errno), I took a different approach. The main reason for this was, that I couldn't convert an error number to the abbreviated error label, only to the message. Example: If I enter 'strerrno 22' I only get 'Invalid argument' (actually, it outputs 'Is a directory', which is wrong), but I can't find out that this is called EINVAL. To circumvent this, I'm outputting all three variants. In addition to this, you can also grep for the error messages directly. Have a look at the source [here](https://github.com/Shadowigor/plugin-errno-grep) for examples.
