### PR TITLE
doctor: check if Git remotes match db URLs

### DIFF
--- a/pkg/omf/functions/core/omf.doctor.fish
+++ b/pkg/omf/functions/core/omf.doctor.fish
@@ -45,6 +45,52 @@ function __omf.doctor.git_version
   end
 end
 
+function __omf.doctor.remote_match_db -a pkg_path
+  if test -z "$pkg_path"
+    # No package specified, run test for all packages
+
+    omf.index.update
+
+    set -l check_result 0
+    for pkg_path in $OMF_PATH/{themes,pkg}/*
+      __omf.doctor.remote_match_db $pkg_path
+      set check_result (math $check_result + $status)
+    end
+    return $check_result
+  end
+
+  # Check if the package remote matches the package repository
+  set -l path_parts
+  begin
+    set -l IFS '/'
+    echo $pkg_path | read -a path_parts
+  end
+  set -l pkg_name $path_parts[-1]
+
+  set -l index_uri (omf.index.stat $pkg_name repository)
+    or begin
+      # Built-in 'omf' and 'fish-spec' are exempt from this check
+      contains -- $pkg_name omf fish-spec; and return 0
+
+      echo (omf::err)"Warning:"(omf::off) "No index entry for "(omf::em)$pkg_name(omf::off)"."
+      echo
+      return 1
+    end
+
+  set -l repo_uri (omf.repo.remote_uri "$pkg_path")
+
+  set -l db_canonical (omf.repo.uri_components $index_uri)
+  set -l repo_canonical (omf.repo.uri_components $repo_uri)
+  if test "$db_canonical" != "$repo_canonical"
+    echo (omf::err)"Warning:"(omf::off) "The remote URI for "(omf::em)"$pkg_name"(omf::off)" doesn't match the URI in OMF's database."
+    echo "Remote URI:  " $repo_uri
+    echo "Index URI:" $index_uri
+    echo
+    return 1
+  end
+  return 0
+end
+
 function omf.doctor
   echo "Oh My Fish version:   "(omf.version)
   echo "OS type:              "(uname)
@@ -55,6 +101,7 @@ function omf.doctor
   __omf.doctor.fish_version; or set -l doctor_failed
   __omf.doctor.git_version; or set -l doctor_failed
   __omf.doctor.theme; or set -l doctor_failed
+  __omf.doctor.remote_match_db; or set -l doctor_failed
 
   if set -q doctor_failed
     echo "If everything you use Oh My Fish for is working fine, please don't worry and just ignore the warnings. Thanks!"

--- a/pkg/omf/functions/repo/omf.repo.remote_uri.fish
+++ b/pkg/omf/functions/repo/omf.repo.remote_uri.fish
@@ -1,0 +1,13 @@
+function omf.repo.remote_uri -a repo_dir -a branch
+  test -z "$repo_dir"; and set repo_dir "$PWD"
+  set -l git_dir (command git -C "$repo_dir" rev-parse --show-toplevel ^/dev/null)
+    and test "$git_dir" = "$repo_dir"
+    or return 1
+
+  test -z "$branch"; and set branch 'master'
+
+  set -l remote (command git -C "$repo_dir" config --get branch."$branch".remote)
+    or set -l remote origin
+
+  command git -C "$repo_dir" config --get remote."$remote".url
+end

--- a/pkg/omf/functions/repo/omf.repo.uri_components.fish
+++ b/pkg/omf/functions/repo/omf.repo.uri_components.fish
@@ -1,0 +1,23 @@
+function omf.repo.uri_components -a uri
+  test -n "$uri"
+    or return 1
+
+  switch $uri
+  case 'git@*'
+    echo $uri | sed -r 's/git@([^:]+):([^/]+)\/([^.]+).*/\1 \2 \3/g'
+  case 'http*://*'
+    echo $uri | sed -r 's/https?:\/\/([^:/]+)(:\d+)?\/([^/]+)\/([^./]+).*/\1 \3 \4/g'
+  case 'ftp*://*'
+    echo $uri | sed -r 's/ftps?:\/\/([^:/]+)(:\d+)?\/([^/]+)\/([^./]+).*/\1 \3 \4/g'
+  case 'ssh://*'
+    echo $uri | sed -r 's/ssh:\/\/([^@]+@)?([^:/]+)(:\d+)?\/([^/]+)\/([^./]+).*/\2 \4 \5/g'
+  case 'git://*'
+    echo $uri | sed -r 's/git:\/\/([^:/]+)(:\d+)?\/([^/]+)\/([^./]+).*/\1 \3 \4/g'
+  case '*@*'
+    echo $uri | sed -r 's/([^@]+@)?([^:]+):([^/]+)\/([^./]+).*/\2 \3 \4/g'
+  case '*'
+    echo $uri
+    return 1
+  end
+  return 0
+end


### PR DESCRIPTION
For each installed package (plugin or theme), the doctor compares the remote URI (default remote configured for fetch on branch 'master') with the URI that's specified in the local package database.
If the _host_, _path_ or _repository name_ differs, a warning is issued. Protocols, logins and ports doesn't matter in this comparison.
As an example, `http://oranja@github.com/path/repo` in the database should have no problem with `git@github.com:path/repo.git` as the remote URI.

Warnings are also issued for installed packages that have no corresponding database entry. The exceptions to this rule are the built-in `omf` and `fish-spec` packages.
