### PR TITLE
Remove vscode plugin

### DIFF
--- a/db/pkg/code
+++ b/db/pkg/code
@@ -1,1 +1,0 @@
-https://github.com/oh-my-fish/plugin-vscode


### PR DESCRIPTION
VSCode can now add the `code` command to PATH by itself.