### PR TITLE
Describe all packages fixed

### DIFF
--- a/pkg/omf/functions/cli/omf.cli.describe.fish
+++ b/pkg/omf/functions/cli/omf.cli.describe.fish
@@ -1,10 +1,4 @@
 function omf.cli.describe -a name
-  switch (count $argv)
-  case 1
-    omf.packages.describe $name
-    return 0
-  case '*'
-    echo (omf::err)"Invalid number of arguments"(omf::off)
-    return 1
-  end
+  omf.packages.describe $name
+  return 0
 end

--- a/pkg/omf/functions/cli/omf.cli.help.fish
+++ b/pkg/omf/functions/cli/omf.cli.help.fish
@@ -19,7 +19,7 @@ function omf.cli.help -a command
       Get information about what packages do.
 
       "(omf::dim)"Usage:"(omf::off)"
-        omf describe                 Get information from all available packages
+        omf describe         Get information from all available packages
         omf describe "(omf::em)"<name>"(omf::off)"  Get information from package by name
 
       "(omf::dim)"Examples:"(omf::off)"

--- a/pkg/omf/functions/packages/omf.packages.describe.fish
+++ b/pkg/omf/functions/packages/omf.packages.describe.fish
@@ -1,7 +1,7 @@
 function omf.packages.describe -a name
   if test (count $argv) -eq 0
     for package in (omf.packages.list --database)
-      echo $package - (omf.describe $package)
+      echo $package - (omf.packages.describe $package)
     end
   else
     set package_path $OMF_PATH/db/pkg/$name


### PR DESCRIPTION
Describe all packages got broken when the package structure changed in 49dda5c2f70517ccb063a264c9aa69744a980aa2. I've added back the functionality to describe all packages.

Also a small doc indent fix too.