### PR TITLE
Streamlined Errors Message

### DIFF
--- a/pkg/omf/functions/packages/omf.packages.install.fish
+++ b/pkg/omf/functions/packages/omf.packages.install.fish
@@ -3,7 +3,7 @@ function __omf.packages.install.success
 end
 
 function __omf.packages.install.error
-  echo (omf::err)"Could not install $argv."(omf::off) 1^&2
+  echo (omf::err)"Could not install $argv:$omf_repo_clone_error"(omf::off) 1^&2
 end
 
 function __omf.packages.install.error.already
@@ -37,6 +37,7 @@ function omf.packages.install -a name_or_url
     end
   else
     echo (omf::dim)"Installing $install_type $name"(omf::off)
+    set -g omf_repo_clone_error
 
     if omf.repo.clone $url $OMF_PATH/$parent_path/$name
       omf.bundle.install $OMF_PATH/$parent_path/$name/bundle
@@ -48,8 +49,10 @@ function omf.packages.install -a name_or_url
       end
     else
       __omf.packages.install.error "$install_type $name"
+      set -e omf_repo_clone_error
       return $OMF_UNKNOWN_ERR
     end
+    set -e omf_repo_clone_error
   end
 
   return 0

--- a/pkg/omf/functions/packages/omf.packages.update.fish
+++ b/pkg/omf/functions/packages/omf.packages.update.fish
@@ -8,17 +8,21 @@ function omf.packages.update -a name
   not test -e $target_path/.git;
     and return 0
 
+  # Create omf_repo_pull_error so that we don't have to pass variables
+  # around
+  set -g omf_repo_pull_error
   omf.repo.pull $target_path
   switch $status
     case 0
       omf.bundle.install $target_path/bundle
       echo (omf::em)"$name successfully updated."(omf::off)
     case 1
-      echo (omf::err)"Could not update $name."(omf::off) 1>&2
+      echo (omf::err)"Could not update $name:$omf_repo_pull_error"(omf::off) 1>&2
       return 1
     case 2
       echo (omf::dim)"$name is already up-to-date."(omf::off)
   end
 
+  set -e omf_repo_pull_error
   return 0
 end

--- a/pkg/omf/functions/repo/omf.repo.clone.fish
+++ b/pkg/omf/functions/repo/omf.repo.clone.fish
@@ -1,3 +1,10 @@
 function omf.repo.clone -a url path
-  command git clone --quiet $url $path
+  set -l omf_repo_clone (command git clone --quiet $url $path 2>&1)
+
+  if test $status -eq 0
+    return 0
+  else
+    set omf_repo_clone_error (echo $omf_repo_clone  | cut -d':' -f{{2-}})
+    return 128
+  end
 end

--- a/pkg/omf/functions/repo/omf.repo.pull.fish
+++ b/pkg/omf/functions/repo/omf.repo.pull.fish
@@ -23,8 +23,11 @@ function omf.repo.pull
 
   # the refspec ensures that '$remote/master' gets updated
   set -l refspec "refs/heads/master:refs/remotes/$remote/master"
-  __omf.repo.git fetch --quiet $remote $refspec ^/dev/null;
-    or return 1
+  set -l omf_repo_pull (__omf.repo.git fetch --quiet $remote $refspec 2>&1)
+  if test $status -ne 0;
+    set omf_repo_pull_error (echo $omf_repo_pull  | cut -d':' -f{{2-}})
+    return 1
+  end
 
   if test (__omf.repo.git rev-list --count master...FETCH_HEAD) -eq 0
     return 2

--- a/pkg/omf/functions/repo/omf.repo.pull.fish
+++ b/pkg/omf/functions/repo/omf.repo.pull.fish
@@ -23,7 +23,7 @@ function omf.repo.pull
 
   # the refspec ensures that '$remote/master' gets updated
   set -l refspec "refs/heads/master:refs/remotes/$remote/master"
-  __omf.repo.git fetch --quiet $remote $refspec;
+  __omf.repo.git fetch --quiet $remote $refspec ^/dev/null;
     or return 1
 
   if test (__omf.repo.git rev-list --count master...FETCH_HEAD) -eq 0


### PR DESCRIPTION
When an update fails instead of getting this garble of output:
```
fatal: unable to access 'https://github.com/oh-my-fish/oh-my-fish.git/': Could not resolve host: github.com
Oh My Fish failed to update.
Please open a new issue here → github.com/oh-my-fish/oh-my-fish/issues
fatal: unable to access 'https://github.com/oh-my-fish/theme-default/': Could not resolve host: github.com
Could not update default.
fatal: unable to access 'https://github.com/oh-my-fish/plugin-errno/': Could not resolve host: github.com
Could not update errno.
fatal: unable to access 'https://github.com/lfiolhais/plugin-homebrew-command-not-found/': Could not resolve host: github.com
Could not update homebrew-command-not-found.
fatal: unable to access 'https://github.com/oh-my-fish/plugin-python/': Could not resolve host: github.com
Could not update python.
fatal: unable to access 'https://github.com/lfiolhais/theme-simple-ass-prompt/': Could not resolve host: github.com
Could not update simple-ass-prompt.
fatal: unable to access 'https://github.com/oh-my-fish/plugin-tab/': Could not resolve host: github.com
Could not update tab.
fatal: unable to access 'https://github.com/oh-my-fish/pkg-z/': Could not resolve host: github.com
Could not update z.
```

You simply get this:
```
Oh My Fish failed to update.
Please open a new issue here → github.com/oh-my-fish/oh-my-fish/issues
Could not update default.
Could not update errno.
Could not update homebrew-command-not-found.
Could not update python.
Could not update simple-ass-prompt.
Could not update tab.
Could not update z.
```