### PR TITLE
init: set correct version number (#323)

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -39,5 +39,5 @@ end
 emit perf:timer:start "Oh My Fish init user config path"
 require --no-bundle --path $OMF_CONFIG
 emit perf:timer:finish "Oh My Fish init user config path"
-set -g OMF_VERSION "1.1.0-dev"
+set -g OMF_VERSION "2"
 emit perf:timer:finish "Oh My Fish initialisation"


### PR DESCRIPTION
It was somehow reverted to `1.1.0-dev`