### PR TITLE
Fix theme key bindings

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -25,13 +25,15 @@ emit perf:timer:finish "Oh My Fish init installed packages"
 functions -q fish_user_key_bindings
   and functions -c fish_user_key_bindings __original_fish_user_key_bindings
 # Override key bindings, calling original if existent
-function fish_user_key_bindings
-  # Read packages key bindings
-  for file in {$OMF_CONFIG,$OMF_PATH}/{,pkg,theme}/*/key_bindings.fish
+function fish_user_key_bindings -V theme
+  # Prepare packages key bindings paths
+  set -l key_bindings $OMF_CONFIG/key_binding?.fish \
+                      {$OMF_CONFIG,$OMF_PATH}/pkg/*/key_bindings.fish \
+                      {$OMF_CONFIG,$OMF_PATH}/themes/$theme/key_binding?.fish
+  # Source all keybindings collected
+  for file in $key_bindings
     source $file
   end
-  # Read custom key bindings file
-  source $OMF_CONFIG/key_bindings.fish ^/dev/null
   # Call original key bindings if existent
   functions -q __original_fish_user_key_bindings
     and __original_fish_user_key_bindings

--- a/pkg/omf/functions/themes/omf.theme.set.fish
+++ b/pkg/omf/functions/themes/omf.theme.set.fish
@@ -30,6 +30,10 @@ function omf.theme.set -a target_theme
     end
   end
 
+  # If key bindings file found, reload fish key bindings
+  test (count {$OMF_CONFIG,$OMF_PATH}/key_binding?.fish) -gt 0
+    and __fish_reload_key_bindings
+
   # Persist the changes
   echo "$target_theme" > "$OMF_CONFIG/theme"
 


### PR DESCRIPTION
This PR fixes the way themes key bindings are treated.

Previous to this PR all installed themes key bindings would be loaded. This PR makes startup code load only current theme key bindings, when existent. 

Also, previously, key bindings wouldn't be reloaded on theme change. This reloads key bindings file when it's found on the theme.

----

@tannhuber, I see your themes use key bindings. Would you like to help us test this PR?

To enable automatic key binding load on themes, move all `bind` calls to `key_bindings.fish` file in theme's repository root directory.

This PR should make `omf t dangerous; omf t budspencer` use `budspencer` key bindings.