### PR TITLE
Fix autoload functions

### DIFF
--- a/pkg/omf/init.fish
+++ b/pkg/omf/init.fish
@@ -23,4 +23,4 @@ function omf::off
   set_color normal
 end
 
-autoload $path/functions/{compat,core,packages,themes,bundle,util,repo,cli}
+autoload $path/functions/{compat,core,packages,themes,bundle,util,repo,cli,search}


### PR DESCRIPTION
Self-explanatory. The search function wasn't in the autoload list.