### PR TITLE
Change ssh-term-helper repository prefix from pkg to plugin to meet new convention

### DIFF
--- a/db/pkg/ssh-term-helper
+++ b/db/pkg/ssh-term-helper
@@ -1,1 +1,1 @@
-https://github.com/wk/pkg-ssh-term-helper
+https://github.com/wk/plugin-ssh-term-helper


### PR DESCRIPTION
Please also remove the oh-my-fish/plugin-ssh repository which contains an older, ambiguously-named version of this plugin which appears to have been bulk-imported, and contains an incorrect LICENSE file.
