### PR TITLE
Update peco repo

### DIFF
--- a/db/pkg/peco
+++ b/db/pkg/peco
@@ -1,1 +1,1 @@
-https://github.com/pkg-gretel/pkg-peco
+https://github.com/oh-my-fish/plugin-peco


### PR DESCRIPTION
When I upgraded my omf peco stopped to work I had to change the repo to this one that seems the one the is currently maintainable.