### PR TITLE
Evaluate OMF_PATH at init time to fix #136

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -109,7 +109,7 @@ function install_omf
   report progress "Adding startup code to fish config file..."
 
   set template "templates/config.fish"
-  set replacements "s|{{OMF_PATH}}|$OMF_PATH|;s|{{OMF_CONFIG}}|$OMF_CONFIG|"
+  set replacements "s|{{OMF_CONFIG}}|$OMF_CONFIG|"
 
   if test "$OMF_CONFIG" != "$XDG_CONFIG_HOME/omf"
     set replacements "$replacements;s|#set|set|"

--- a/templates/config.fish
+++ b/templates/config.fish
@@ -1,5 +1,7 @@
 # Path to Oh My Fish install.
-set -gx OMF_PATH "{{OMF_PATH}}"
+set -q XDG_DATA_HOME
+  and set -gx OMF_PATH "$XDG_DATA_HOME/omf"
+  or set -gx OMF_PATH "$HOME/.local/share/omf"
 
 # Customize Oh My Fish configuration path.
 #set -gx OMF_CONFIG "{{OMF_CONFIG}}"


### PR DESCRIPTION
If we want to evaluate `$OMF_PATH at init time instead of install time, this is how we can do it. A fair reason we might want to do this is it makes putting `config.fish` into a dotfiles repo make more sense. Currently hardcoding the paths makes the config file machine-specific.