### PR TITLE
Add virtualfish plugin to the registry

### DIFF
--- a/db/pkg/virtualfish
+++ b/db/pkg/virtualfish
@@ -1,1 +1,1 @@
-https://github.com/timanin/plugin-virtualfish.git
+https://github.com/oh-my-fish/plugin-virtualfish.git

--- a/db/pkg/virtualfish
+++ b/db/pkg/virtualfish
@@ -1,0 +1,1 @@
+https://github.com/timanin/plugin-virtualfish.git


### PR DESCRIPTION
I am using the [virtualfish](http://virtualfish.readthedocs.io/en/latest/install.html#installing) to manage the python virtual environments and didn't want to put `eval (python -m virtualfish)` into my `config.fish` or `init.fish`. So I created this plugin to manage this functionality easier.

I have noticed some themes had integrated the virtualfish, but I find having it wrapper in a plugin more flexible.