### PR TITLE
Refactor installer to support offline installs and more control over user data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,14 @@ addons:
     - tree
 
 before_install:
+  - tools/travis-install-git.sh
   - source tools/travis-github-pr-integration.sh
   - tools/travis-install-fish.sh
 
 before_script:
   - tree -h
   - export
-  - fish $TRAVIS_BUILD_DIR/bin/install
+  - fish $TRAVIS_BUILD_DIR/bin/install --offline --noninteractive --yes
 
 script:
   - tests/run.fish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,7 @@
-FROM ohmyfish/fish:2.2.0
+FROM ohmyfish/fish:2.3.0
 
 COPY . /src/oh-my-fish
 
-# Prevent install from opening a new fish shell
-ENV CI WORKAROUND
-
-# Replace this when offline installation is supported
-ARG OMF_REPO_BRANCH=master
-ARG OMF_REPO_URI=https://github.com/oh-my-fish/oh-my-fish
-
-RUN fish /src/oh-my-fish/bin/install
+RUN fish /src/oh-my-fish/bin/install --offline --noninteractive --yes
 
 WORKDIR /root/.local/share/omf

--- a/README.md
+++ b/README.md
@@ -16,19 +16,34 @@ Oh My Fish provides core infrastructure to allow you to install packages which e
 
 ## Installation
 
-```fish
-curl -L https://github.com/oh-my-fish/oh-my-fish/raw/master/bin/install | fish
-omf help
-```
-
-Or _download_ and run it yourself:
+You can get started right away with the default setup by running this in your terminal:
 
 ```fish
-curl -L https://github.com/oh-my-fish/oh-my-fish/raw/master/bin/install > install
-fish install
+curl -L http://get.oh-my.fish | fish
 ```
 
-# Getting Started
+This will download the installer script and start the installation. Alternatively, you can download the installer and customize your install:
+
+```fish
+curl -L http://get.oh-my.fish > install
+fish install --path=data/oh-my-fish --config=$HOME/.my-omf-config
+```
+
+You can also install Oh My Fish with Git or with an offline source tarball downloaded from the [releases page][releases]:
+
+```fish
+# with git
+$ git clone https://github.com/oh-my-fish/oh-my-fish
+$ cd oh-my-fish
+$ bin/install --offline
+# with a tarball
+$ curl -L http://get.oh-my.fish > install
+$ fish install --offline=omf.tar.gz
+```
+
+Run `install --help` for a complete list of install options you can customize.
+
+## Getting Started
 
 Oh My Fish includes a small utility `omf` to fetch and install new packages and themes.
 
@@ -126,10 +141,9 @@ Every time a package/theme is installed or removed, the `bundle` file is updated
 
 Oh My Fish uses an advanced and well defined plugin architecture to ease plugin development, including init/uninstall hooks, function and completion autoloading. [See the packages documentation](docs/en-US/Packages.md) for more details.
 
+
 [fishshell]: http://fishshell.com
-
 [contributors]: https://github.com/oh-my-fish/oh-my-fish/graphs/contributors
-
 [omf-pulls-link]: https://github.com/oh-my-fish/oh-my-fish/pulls
-
 [omf-issues-new]: https://github.com/oh-my-fish/oh-my-fish/issues/new
+[releases]: https://github.com/oh-my-fish/oh-my-fish/releases

--- a/bin/install
+++ b/bin/install
@@ -1,158 +1,524 @@
 #!/usr/bin/env fish
-#
-# USAGE
-#   #1: curl -L https://github.com/oh-my-fish/oh-my-fish/raw/master/bin/install | fish
-#   #2: curl -L https://github.com/oh-my-fish/oh-my-fish/raw/master/bin/install > install; and fish install
-#   #3: env OMF_CONFIG=~/.omf curl -L https://github.com/oh-my-fish/oh-my-fish/raw/master/bin/install | fish
-#
-# ENV
-#   XDG_DATA_HOME       Base directory (~/.local/share)
-#   XDG_CONFIG_HOME     Base configuration directory (~/.config)
-#
-#   - See XDG Base Directory Specification:
-#   - https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-#
-#   FISH_CONFIG       Fish shell configuration file
-#
-#   OMF_PATH          Oh My Fish installation directory
-#   OMF_CONFIG        Oh My Fish configuration directory
-#
-#   OMF_REPO_URI      Oh My Fish source git repository
-#   OMF_REPO_BRANCH   Oh My Fish source repository branch
+# Oh My Fish installer. See `install --help` for usage.
 
-
-set -q XDG_DATA_HOME;   or set XDG_DATA_HOME "$HOME/.local/share"
-set -q XDG_CONFIG_HOME; or set XDG_CONFIG_HOME "$HOME/.config"
-
-set -q FISH_CONFIG;     or set FISH_CONFIG "$XDG_CONFIG_HOME/fish"
-
-set -q OMF_PATH;        or set OMF_PATH "$XDG_DATA_HOME/omf"
-set -q OMF_CONFIG;      or set OMF_CONFIG "$XDG_CONFIG_HOME/omf"
-
+# Set environment options.
 set -q OMF_REPO_URI;    or set OMF_REPO_URI "https://github.com/oh-my-fish/oh-my-fish"
 set -q OMF_REPO_BRANCH; or set OMF_REPO_BRANCH "master"
 
-set OMF_FISH_MIN_VER 2 2 0
 
-function available -a name
-  type "$name" >/dev/null 2>&1
-end
+function main
+  # Set default settings
+  set -q XDG_DATA_HOME
+    and set -g OMF_PATH_DEFAULT "$XDG_DATA_HOME/omf"
+    or set -g OMF_PATH_DEFAULT "$HOME/.local/share/omf"
 
-function report -a what message
-  switch $what
-  case 'progress'
-    set_color yellow
-  case 'success'
-    set_color green
-  case 'error'
-    set_color red
-    printf "$message\n"
-    exit 1
+  set -q XDG_CONFIG_HOME
+    and set -g CONFIG_PATH "$XDG_CONFIG_HOME"
+    or set -g CONFIG_PATH "$HOME/.config"
+
+  set -g OMF_CONFIG_DEFAULT "$CONFIG_PATH/omf"
+  set -g FISH_CONFIG "$CONFIG_PATH/fish"
+
+  set -g OMF_PATH "$OMF_PATH_DEFAULT"
+  set -g OMF_CONFIG "$OMF_CONFIG_DEFAULT"
+
+  # Ensure repository URL ends with .git
+  set OMF_REPO_URI (echo $OMF_REPO_URI | command sed 's/\.git//').git
+
+  # Parse command args
+  while set -q argv[1]
+    switch "$argv[1]"
+      case --help -h '/?'
+        echo "Usage: install [options]
+  Install Oh My Fish
+
+Options:
+  --config=<path>         Put config in a specific path (default is $OMF_CONFIG_DEFAULT).
+  --help, -h              Show this help message.
+  --noninteractive        Disable interactive questions (assume no, use with --yes to assume yes).
+  --offline[=<path>]      Offline install, optionally specifying a tar or directory to use.
+  --path=<path>           Use a specific install path (default is $OMF_PATH_DEFAULT).
+  --uninstall             Uninstall existing installation instead of installing.
+  --yes, -y               Assume yes for interactive questions.
+"
+        return 0
+
+      case '--config=*'
+        echo "$argv[1]" | command cut -d= -f2 | read -g OMF_CONFIG
+
+      case --noninteractive
+        set -g NONINTERACTIVE
+
+      case --offline
+        set -g OFFLINE
+
+      case '--offline=*'
+        set -g OFFLINE
+        echo "$argv[1]" | command cut -d= -f2 | read -g OFFLINE_PATH
+
+      case '--path=*'
+        echo "$argv[1]" | command cut -d= -f2 | read -g OMF_PATH
+
+      case --uninstall
+        set -g UNINSTALL
+
+      case --yes -y
+        set -g ASSUME_YES
+
+      case '*'
+        abort "Unrecognized option '$argv[1]'. Try 'install --help' for usage."
+    end
+    set -e argv[1]
   end
 
-  printf "$message\n"
+  # Ensure the environment meets all of the requirements.
+  assert_cmds
+  assert_fish_version_compatible 2.2.0
+  assert_git_version_compatible 1.9.5
+  assert_interactive
+
+  # If the user wants to uninstall, jump to uninstallation and exit.
+  if set -q UNINSTALL
+    uninstall_omf
+    return
+  end
+
+  # Check if OMF is already installed.
+  if test -d "$OMF_PATH"
+    if is_install_dir "$OMF_PATH"
+      say "Existing installation detected at $OMF_PATH"
+
+      confirm_yes "Would you like to remove the existing installation?"
+      uninstall_omf
+    else
+      abort "Target directory $OMF_PATH already exists"
+    end
+  end
+
+  # Begin the install process.
+  install_omf
+
+  # We made it!
+  say "Installation successful!"
+
+  # Open a brand new shell if we are in interactive mode.
+  set -q NONINTERACTIVE
+    or exec fish < /dev/tty
+
+  return 0
 end
 
-function fish_version_compatible
-  set -q FISH_VERSION; or set -l FISH_VERSION $version
-  set -l major (echo $FISH_VERSION | cut -d. -f1)
-  set -l minor (echo $FISH_VERSION | cut -d. -f2)
 
-  return (test $major = $OMF_FISH_MIN_VER[1] -a $minor -ge $OMF_FISH_MIN_VER[2])
+# Add an exit hook to display a message if the installer aborts or errors.
+function on_exit -p %self
+  if not contains $argv[3] 0 2
+    echo -e "\nOh My Fish installation failed.\n\nIf you think that it's a bug, please open an\nissue with the complete installation log here:\n\nhttp://github.com/oh-my-fish/oh-my-fish/issues"
+  end
 end
 
 
+# Installs Oh My Fish.
+function install_omf
+  say "Installing Oh My Fish to $OMF_PATH..."
+
+  # Prepare paths
+  command mkdir -p (dirname "$OMF_PATH")
+
+  # Install step
+  if set -q OFFLINE
+    install_offline
+  else
+    install_from_github
+  end
+
+  # Bootstrap step
+  install_bootstrap
+end
+
+
+# Downloads and installs the framework from GitHub.
+function install_from_github
+  say "Cloning $OMF_REPO_BRANCH from $OMF_REPO_URI..."
+
+  if not command git clone -q --depth 1 -b $OMF_REPO_BRANCH $OMF_REPO_URI "$OMF_PATH"
+    abort "Error cloning repository!"
+  end
+
+  set_git_remotes
+end
+
+
+# Install the framework from an offline copy of the source.
+function install_offline
+  # Prepare the path
+  if set -q OFFLINE_PATH
+    # Make sure the given path exists
+    if not test -e "$OFFLINE_PATH"
+      abort "Local installation does not exist"
+    end
+  else
+    # If no path was set, check if the installer is running inside of the source directory.
+    set -l path (command dirname (command dirname (builtin status -f)))
+
+    if is_install_dir "$path"
+      set OFFLINE_PATH "$path"
+    # Try using the current working directory as the source.
+    else if is_install_dir "$PWD"
+      set OFFLINE_PATH "$PWD"
+    else
+      # We tried our best.
+      abort "Could not find local installation source"
+    end
+  end
+
+  # Check if the path is some sort of tar.
+  if test -f "$OFFLINE_PATH"
+    say "Offline path is a file, assuming tar archive..."
+
+    command tar -xf "$OFFLINE_PATH" -C "$OMF_PATH"
+      or abort "Could not extract tar file $OFFLINE_PATH"
+
+    return
+  end
+
+  # At this point, path must be a directory.
+  if not test -d "$OFFLINE_PATH"
+    abort "$OFFLINE_PATH is not a directory"
+  end
+
+  # Make sure the given path is actually the OMF source.
+  if not is_install_dir "$OFFLINE_PATH"
+    abort "$OFFLINE_PATH is not a valid local installation source"
+  end
+
+  # Copy the source into the install location.
+  command cp -r "$OFFLINE_PATH" "$OMF_PATH"
+    or abort "Failed to copy source!"
+
+  # Set up Git remotes only if the offline install is a Git repository.
+  test -d "$OMF_PATH/.git"
+    and set_git_remotes
+
+  return 0
+end
+
+
+# Set upstream remotes on the framework Git repository.
+function set_git_remotes
+  set git_upstream (command git --git-dir "$OMF_PATH/.git" --work-tree "$OMF_PATH" config remote.upstream.url)
+
+  if test -z "$git_upstream"
+    command git --git-dir "$OMF_PATH/.git" --work-tree "$OMF_PATH" remote add upstream $OMF_REPO_URI
+  else
+    command git --git-dir "$OMF_PATH/.git" --work-tree "$OMF_PATH" remote set-url upstream $OMF_REPO_URI
+  end
+end
+
+
+# Sets up the necessary bootstrap code for Fish to load OMF.
+function install_bootstrap
+  set -l fish_config_file "$FISH_CONFIG/config.fish"
+  set -l vendor_config_file "$FISH_CONFIG/conf.d/omf.fish"
+
+  # Create the Fish config directory if it doesn't exist yet (if the first thing the user runs with Fish is this
+  # installer, for example).
+  command mkdir -p "$FISH_CONFIG"
+
+  # If Oh My Fish is already configured and ready to go, there's nothing else we need to do here.
+  if is_omf_loaded
+    return 0
+
+  # Fish 2.3.0+ supports conf.d which is for vendors to manage, so we can just plop an init file under our control.
+  else if is_version_compatible 2.3.0 (get_fish_version)
+    say "Writing bootstrap to $vendor_config_file..."
+    command mkdir -p "$FISH_CONFIG/conf.d"
+    generate_bootstrap > "$vendor_config_file"
+
+  # If the user doesn't have their own config file, we'll just use that as our bootstrap.
+  else if not test -e "$fish_config_file"
+    say "Writing bootstrap to $fish_config_file..."
+    generate_bootstrap > "$fish_config_file"
+
+  # Even though config.fish already exists, we can prepend to it if the user is OK with it.
+  else if confirm "Would you like Oh My Fish to be added to your configuration automatically?"
+    say "Prepending bootstrap to $fish_config_file..."
+
+    # Create a temporary file to store the combined config so that we can write atomically.
+    generate_bootstrap | command cat - "$fish_config_file" > "$fish_config_file.tmp"
+      or abort "Error prepending config file"
+
+    # Swap in the prepended file.
+    command mv "$fish_config_file.tmp" "$fish_config_file"
+      or abort "Error moving file to $fish_config_file"
+
+  # We don't have any options left, so let the user set up the bootstrap manually.
+  else
+    say "For Oh My Fish to work properly, please paste the code below into a file that Fish can run at startup:"
+    echo
+    generate_bootstrap
+  end
+
+  # Backup the user's theme settings. This can be removed when OMF no longer touches this file to switch themes.
+  backup_file "$FISH_CONFIG/functions/fish_prompt.fish"
+
+  say "Building Oh My Fish configuration..."
+
+  # Set up the Oh My Fish configuration directory.
+  if not test -d "$OMF_CONFIG"
+    command mkdir -p "$OMF_CONFIG"
+  end
+
+  test -f "$OMF_CONFIG/bundle";
+    or echo "theme default" > "$OMF_CONFIG/bundle"
+  test -f "$OMF_CONFIG/theme"
+    or echo "default" > "$OMF_CONFIG/theme"
+
+  # Install plugins
+  fish -c "omf install"
+    or abort "Error installing plugins"
+end
+
+
+# Generates the bootstrap code used to initialize Oh My Fish on shell startup.
+function generate_bootstrap
+  echo "# Path to Oh My Fish install."
+
+  if test "$OMF_PATH" = "$OMF_PATH_DEFAULT"
+    echo "\
+set -q XDG_DATA_HOME
+  and set -gx OMF_PATH \"\$XDG_DATA_HOME/omf\"
+  or set -gx OMF_PATH \"\$HOME/.local/share/omf\""
+  else
+    echo "set -gx OMF_PATH '$OMF_PATH'"
+  end
+
+  if test "$OMF_CONFIG" != "$OMF_CONFIG_DEFAULT"
+    echo "
+# Customize Oh My Fish configuration path.
+set -gx OMF_CONFIG '$OMF_CONFIG'"
+  end
+
+  echo "
+# Load Oh My Fish configuration.
+source \$OMF_PATH/init.fish"
+end
+
+
+# Uninstalls an existing OMF installation.
+function uninstall_omf
+  is_install_dir "$OMF_PATH"
+    or abort "No installation detected at $OMF_PATH"
+
+  say (set_color -o red ^ /dev/null)"This will uninstall Oh My Fish and all plugins and themes from $OMF_PATH."(set_color normal ^ /dev/null)
+
+  # If we installed the bootstrap to the user's config, let them know they need to remove it themselves.
+  if begin; test -f "$FISH_CONFIG/config.fish"; and grep -q OMF_PATH "$FISH_CONFIG/config.fish"; end
+    say (set_color -o ^ /dev/null)"Your configuration will not be modified. You may need to remove Oh My Fish startup code from $FISH_CONFIG/config.fish."(set_color normal ^ /dev/null)
+  end
+
+  confirm_yes "Are you sure you want to continue?"
+  say "Uninstalling from $OMF_PATH..."
+
+  # Trigger package uninstall events
+  for path in $OMF_PATH/pkg/*
+    set -l package (command basename "$path")
+
+    test -f "$path/hooks/uninstall.fish"
+      and source "$path/hooks/uninstall.fish"
+
+    test -f "$path/uninstall.fish"
+      and source "$path/uninstall.fish"
+
+    emit uninstall_$package
+  end
+
+  # Remove the core framework
+  command rm -rf "$OMF_PATH"
+    or abort "Uninstall failed"
+
+  # Remove the bootstrap if it is managed by us
+  set -l vendor_config_file "$FISH_CONFIG/conf.d/omf.fish"
+  if test -e "$vendor_config_file"
+    command rm "$vendor_config_file"
+      or abort "Failed to remove bootstrap file"
+  end
+
+  # Restore backed-up files
+  restore_backup_file "$FISH_CONFIG/config.fish"
+  restore_backup_file "$FISH_CONFIG/functions/fish_prompt.fish"
+
+  say "Uninstall complete"
+end
+
+
+# Makes a backup of a given file.
 function backup_file -a file_path
   test -e "$file_path"; or return 1
 
-  set -l path (dirname $file_path)
-  set -l file (basename $file_path)
-  set -l name (echo $file | cut -d. -f1)
+  set -l path (command dirname $file_path)
+  set -l file (command basename $file_path)
+  set -l name (echo $file | command cut -d. -f1)
 
-  set -l timestamp (date +%s)
+  set -l timestamp (command date +%s)
   set -l backup_file "$path/$name.$timestamp.copy"
 
-  report progress "Existent $file found at $path"
-  report progress "↳ Moving to $backup_file"
+  say "Existent $file found at $path"
+  say "↳ Moving to $backup_file"
 
-  if not mv "$file_path" $backup_file 2>/dev/null
-    report error "Aborting: Could not backup $file_path"
+  if not command mv "$file_path" $backup_file 2>/dev/null
+    abort "Could not backup $file_path"
   end
 
   return 0
 end
 
-function install_omf
-  # Grant repository URL ends with .git
-  set git_uri (echo $OMF_REPO_URI | sed 's/\.git//').git
 
-  report progress "Cloning $OMF_REPO_BRANCH from $git_uri..."
-  if not git clone -q --depth 1 -b $OMF_REPO_BRANCH $git_uri "$OMF_PATH"
-    report error "Error cloning repository!"
+# Restores a backed-up file to its original location.
+function restore_backup_file -a file_path
+  set -l path (command dirname $file_path)
+  set -l file (command basename $file_path)
+  set -l name (echo $file | cut -d. -f1)
+  set -l backup_file_list $path/$name.*.copy
+  set -l backup_file_path (echo $backup_file_list | command tr ' ' '\n' | command sort -r | command head -1)
+
+  if test -e "$backup_file_path"
+    say "Restoring backup file to $path/$file"
+    command mv "$backup_file_path" "$path/$file" ^/dev/null
+      or abort "Could not restore backup $backup_file_path"
   end
-
-  set git_upstream (git --git-dir "$OMF_PATH/.git" --work-tree "$OMF_PATH" config remote.upstream.url)
-
-  if test -z "$git_upstream"
-    git --git-dir "$OMF_PATH/.git" --work-tree "$OMF_PATH" remote add upstream $git_uri
-  else
-    git --git-dir "$OMF_PATH/.git" --work-tree "$OMF_PATH" remote set-url upstream $git_uri
-  end
-
-  set fish_config_file "$FISH_CONFIG/config.fish"
-
-  backup_file "$FISH_CONFIG/config.fish";
-    or mkdir -p "$FISH_CONFIG"
-
-  backup_file "$FISH_CONFIG/functions/fish_prompt.fish"
-
-  report progress "Adding startup code to fish config file..."
-
-  set template "templates/config.fish"
-  set replacements "s|{{OMF_CONFIG}}|$OMF_CONFIG|"
-
-  if test "$OMF_CONFIG" != "$XDG_CONFIG_HOME/omf"
-    set replacements "$replacements;s|#set|set|"
-  end
-
-  sed  "$replacements" "$OMF_PATH/$template" > "$fish_config_file"
-
-  report progress "Building Oh My Fish configuration..."
-
-  if not test -d "$OMF_CONFIG"
-    mkdir -p "$OMF_CONFIG"
-  end
-
-  test -f "$OMF_CONFIG/bundle"; or echo "theme default" > "$OMF_CONFIG/bundle"
-  test -f "$OMF_CONFIG/theme";  or echo "default" > "$OMF_CONFIG/theme"
-
-  fish -c "omf install"
 end
 
-function main
-  report progress "Installing Oh My Fish to $OMF_PATH..."
 
-  if test -d "$OMF_PATH"
-    report error "Aborting: Existing installation detected."
-  end
-
-  if not available git
-    report error "Aborting: Installation requires Git."
-  end
-
-  if not fish_version_compatible
-    set -l minimum_version_string (echo $OMF_FISH_MIN_VER | sed 's/ /./g')
-    report error "Aborting: Detected fish $version, but Oh My Fish requires fish $minimum_version_string or greater."
-  end
-
-  if install_omf
-    report success "Installation successful!"
-    set -q CI; or exec fish < /dev/tty
+# Gets the version of Fish installed.
+function get_fish_version
+  if set -q FISH_VERSION
+    echo $FISH_VERSION
+  else if set -q version
+    echo $version
   else
-    report error "Oh My Fish installation failed.\n\nIf you think that it's a bug, please open an\nissue with the complete installation log here:\n\nhttp://github.com/oh-my-fish/oh-my-fish/issues"
+    return 1
   end
-
-  exit 0
 end
 
-main
+
+# Gets the version of Git installed.
+function get_git_version
+  type -f -q git
+    and command git --version | command cut -d' ' -f3
+end
+
+
+# Checks if a path looks like an OMF install.
+function is_install_dir -a path
+  test -n "$path"
+    and test -d "$path"
+    and test -d "$path/pkg/omf"
+end
+
+
+# Checks if OMF is set up properly and working.
+function is_omf_loaded
+  command fish -c "omf --version" > /dev/null ^&1
+end
+
+
+# Tests if the right-hand side version is equal to or greater than the left-hand side version.
+function is_version_compatible -a lhs rhs
+  # Both arguments must be given.
+  set -q argv[2]
+    or return 1
+
+  # Sort the versions to get the lesser one.
+  set -l sorted (printf "$lhs\n$rhs\n" | command sort -n -t '.' -k 1,1 -k 2,2 -k 3,3 -k 4,4)
+
+  # Left-hand side must be the smallest version.
+  test "$lhs" = "$sorted[1]"
+end
+
+
+# Assert that all tools we need are available.
+function assert_cmds
+  set -l cmds basename cp cut date dirname fish fold git head mkdir mv rm sed sort tar tr
+
+  for cmd in $cmds
+    type -f -q $cmd
+      or abort "Command '$cmd' not found"
+  end
+end
+
+
+# Assert that a minimum required version of Fish is installed.
+function assert_fish_version_compatible -a required_version
+  set -l installed_version (get_fish_version)
+    and is_version_compatible $required_version $installed_version
+    or abort "Fish version $required_version or greater required; you have $installed_version"
+end
+
+
+# Assert that a minimum required version of Git is installed.
+function assert_git_version_compatible -a required_version
+  set -l installed_version (get_git_version)
+    and is_version_compatible $required_version $installed_version
+    or abort "Git version $required_version or greater required; you have $installed_version"
+end
+
+
+# Ensures the keyboard is readable if in interactive mode.
+function assert_interactive
+  set -q NONINTERACTIVE
+    and return
+
+  test -c /dev/tty -a -r /dev/tty
+    and echo -n > /dev/tty ^ /dev/null
+    or abort "Running interactively, but can't read from tty (try running with --noninteractive)"
+end
+
+
+# Print a message to the user.
+function say -a message
+  printf "$message\n" | command fold -s -w 80
+end
+
+
+# Aborts the installer and displays an error.
+function abort -a message code
+  if test -z "$code"
+    set code 1
+  end
+
+  if test -n "$message"
+    printf "%sInstall aborted: $message%s\n" (set_color -o red ^ /dev/null) (set_color normal ^ /dev/null) >&2
+  else
+    printf "%sInstall aborted%s\n" (set_color -o red ^ /dev/null) (set_color normal ^ /dev/null) >&2
+  end
+
+  exit $code
+end
+
+
+# Asks the user for confirmation.
+function confirm -a message
+  # Return true if we assume yes for all questions.
+  set -q ASSUME_YES
+    and return 0
+
+  # Return false if we can't ask the question.
+  set -q NONINTERACTIVE
+    and return 1
+
+  printf "%s$message (y/N): %s" (set_color yellow ^ /dev/null) (set_color normal ^ /dev/null)
+  read -l answer < /dev/tty
+    or abort "Failed to read from tty"
+
+  not test "$answer" != y -a "$answer" != Y -a "$answer" != yes
+end
+
+
+# Asks the user for a confirmation or aborts.
+function confirm_yes -a message
+  confirm "$message"
+    or abort "Canceled by user" 2
+end
+
+
+main $argv

--- a/pkg/omf/functions/cli/omf.cli.destroy.fish
+++ b/pkg/omf/functions/cli/omf.cli.destroy.fish
@@ -1,11 +1,3 @@
 function omf.cli.destroy
-  echo (omf::err)"This will destroy your Oh My Fish installation!"(omf::off)
-  read -l decision -p 'echo -n "Are you sure you want to continue? (y/N) "'
-
-  switch $decision
-  case 'y' 'Y'
-    omf.destroy
-  case '*'
-    echo (omf::err)"Aborted!"(omf::off)
-  end
+  omf.destroy
 end

--- a/pkg/omf/functions/core/omf.destroy.fish
+++ b/pkg/omf/functions/core/omf.destroy.fish
@@ -1,38 +1,7 @@
-function __omf.destroy.restore_backup -a file_path
-  set -l path (dirname $file_path)
-  set -l file (basename $file_path)
-  set -l name (echo $file | cut -d. -f1)
-  set -l backup_file_list $path/$name.*.copy
-  set -l backup_file_path (echo $backup_file_list | tr ' ' '\n' | sort -r | head -1)
-
-  if test -e "$backup_file_path"
-    mv "$backup_file_path" "$path/$file" ^/dev/null
-  else
-    rm -f "$path/$file" ^/dev/null
-  end
-end
-
 function omf.destroy -d "Remove Oh My Fish"
-  echo (omf::dim)"Removing Oh My Fish..."(omf::off)
+  # Run the uninstaller
+  fish "$OMF_PATH/bin/install" --uninstall "--path=$OMF_PATH" "--config=$OMF_CONFIG"
 
-  set -l installed_package_path $OMF_PATH/pkg/*
-
-  for pkg in (basename -a $installed_package_path)
-    emit uninstall_$pkg
-  end
-
-  set -q XDG_CONFIG_HOME;
-    or set -l XDG_CONFIG_HOME "$HOME/.config"
-
-  set -l fish_config_home $XDG_CONFIG_HOME/fish
-  set -l fish_prompt_home $fish_config_home/functions
-
-  __omf.destroy.restore_backup "$fish_config_home/config.fish"
-  __omf.destroy.restore_backup "$fish_prompt_home/fish_prompt.fish"
-
-  if test "$OMF_PATH" != "$HOME"
-    rm -rf "$OMF_PATH"
-  end
-
+  # Start a new OMF-free shell
   set -q CI; or exec fish < /dev/tty
 end

--- a/tools/travis-install-git.sh
+++ b/tools/travis-install-git.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then
+  sudo add-apt-repository -y ppa:git-core/ppa
+  sudo apt-get update
+  sudo apt-get install --only-upgrade -y git
+else
+  brew update
+  brew install git
+fi


### PR DESCRIPTION
Completely refactors the installer. The code is more organized and should be more reliable and consistent.

The new installer supports:
- offline installation (#167, #185)
- interactive questions and acknowledgements
- preserving and ignoring user's config files (#267, #274, #281)
- bootstrap code in `config.fish` is no longer required for Fish 2.3.0+, uses `conf.d` instead
- customizable install paths via command flags