### PR TITLE
Add GPG Package for OMF

### DIFF
--- a/db/pkg/gpg
+++ b/db/pkg/gpg
@@ -1,0 +1,1 @@
+https://github.com/benkutil/omf-pkg-gpg


### PR DESCRIPTION
Instead of manually adding this to your fish config, I’ve wrapped [kvs’](https://github.com/kvs) [gnupg script](https://github.com/kvs/dotfiles/blob/master/fish/gnupg.fish) as an omf plugin.
