### PR TITLE
Basic infra for mercurial support

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -10,7 +10,7 @@ emit perf:timer:start "Oh My Fish initialisation"
 # Read current theme
 read -l theme < $OMF_CONFIG/theme
 # Prepare Oh My Fish paths
-set -l core_function_path $OMF_PATH/lib{,/git}
+set -l core_function_path $OMF_PATH/lib{,/git,/hg}
 set -l theme_function_path {$OMF_CONFIG,$OMF_PATH}/themes*/$theme{,/functions}
 # Autoload core library
 set fish_function_path $fish_function_path[1] \

--- a/lib/hg/hg_branch_or_bookmark_name.fish
+++ b/lib/hg/hg_branch_or_bookmark_name.fish
@@ -1,4 +1,4 @@
 function hg_branch_or_bookmark_name -d "Get current branch / bookmark name" -a repo_root
-  command cat $repo_root'/bookmarks.current' ^/dev/null;
-    or command cat $repo_root'/branch'
+  command cat $repo_root'/.hg/bookmarks.current' ^/dev/null;
+    or command cat $repo_root'/.hg/branch'
 end

--- a/lib/hg/hg_branch_or_bookmark_name.fish
+++ b/lib/hg/hg_branch_or_bookmark_name.fish
@@ -1,0 +1,4 @@
+function hg_branch_or_bookmark_name -d "Get current branch / bookmark name" -a repo_root
+  command cat $repo_root'/bookmarks.current' ^/dev/null;
+    or command cat $repo_root'/branch'
+end

--- a/lib/hg/hg_repo_root.fish
+++ b/lib/hg/hg_repo_root.fish
@@ -2,8 +2,10 @@ function hg_repo_root -d "Return the root of the hg repository"
   set -l dir $PWD
   while test $dir != '/'
     if test -d $dir'/.hg'
-      echo -n $dir'/.hg'
+      echo -n $dir
+      return 0
     end
-    set -l dir (dirname $dir)
+    set -l dir (dirname $dir ^/dev/null)
   end
+  return 1
 end

--- a/lib/hg/hg_repo_root.fish
+++ b/lib/hg/hg_repo_root.fish
@@ -1,0 +1,9 @@
+function hg_repo_root -d "Return the root of the hg repository"
+  set -l dir $PWD
+  while test $dir != '/'
+    if test -d $dir'/.hg'
+      echo -n $dir'/.hg'
+    end
+    set -l dir (dirname $dir)
+  end
+end


### PR DESCRIPTION
I'm using these utils in the oh-my-fish/theme-default#7 to show a basic branch / bookmark prompt for hg repos for the default OMF install.

I didn't use any `hg` commands because the overhead of starting up python is too much for an operation on every shell.
ref: https://www.mercurial-scm.org/pipermail/mercurial/2014-November/047694.html
ref2: http://patrickoscity.de/blog/building-a-fast-mercurial-prompt

Not sure if this belongs in a plugin, but it seems up there with basic git functionality to me. (Yes, I use mercurial quite a bit.)

Not doing anything else fancy like dirty working dir etc out of laziness, though I assume looking at the files in `$repo/.hg/` I can do that too.

re: test plan, I'm using this locally quite happily. So I guess it works. :)