### PR TITLE
registry: add archlinux plugin (fix #395)

### DIFF
--- a/db/pkg/archlinux
+++ b/db/pkg/archlinux
@@ -1,0 +1,1 @@
+https://github.com/oh-my-fish/plugin-archlinux


### PR DESCRIPTION
This adds again Arch Linux plugin, which was left out of registry in one of our silly plugin structure migrations.