### PR TITLE
assert fish version before asserting commands

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -72,8 +72,8 @@ Options:
   end
 
   # Ensure the environment meets all of the requirements.
-  assert_cmds
   assert_fish_version_compatible 2.2.0
+  assert_cmds
   assert_git_version_compatible 1.9.5
   assert_interactive
 

--- a/bin/install
+++ b/bin/install
@@ -73,8 +73,8 @@ Options:
 
   # Ensure the environment meets all of the requirements.
   assert_fish_version_compatible 2.2.0
-  assert_cmds
   assert_git_version_compatible 1.9.5
+  assert_cmds
   assert_interactive
 
   # If the user wants to uninstall, jump to uninstallation and exit.
@@ -441,17 +441,6 @@ function is_version_compatible -a lhs rhs
 end
 
 
-# Assert that all tools we need are available.
-function assert_cmds
-  set -l cmds basename cp cut date dirname fish fold git head mkdir mv rm sed sort tar tr
-
-  for cmd in $cmds
-    type -f -q $cmd
-      or abort "Command '$cmd' not found"
-  end
-end
-
-
 # Assert that a minimum required version of Fish is installed.
 function assert_fish_version_compatible -a required_version
   set -l installed_version (get_fish_version)
@@ -465,6 +454,17 @@ function assert_git_version_compatible -a required_version
   set -l installed_version (get_git_version)
     and is_version_compatible $required_version $installed_version
     or abort "Git version $required_version or greater required; you have $installed_version"
+end
+
+
+# Assert that all tools we need are available.
+function assert_cmds
+  set -l cmds basename cp cut date dirname fold head mkdir mv rm sed sort tar tr
+
+  for cmd in $cmds
+    type -f -q $cmd
+      or abort "Command '$cmd' not found"
+  end
 end
 
 


### PR DESCRIPTION
A suggestion for resolving issue #398, this ensures that the correct error message is displayed if the users environment does not meet the requirements