### PR TITLE
add pkg cd

### DIFF
--- a/db/pkg/cd
+++ b/db/pkg/cd
@@ -1,0 +1,1 @@
+https://github.com/oh-my-fish/plugin-cd


### PR DESCRIPTION
Package cd provides a new cd command to help you change the current working directory fast. It's a proxy directive of the buildin cd command with an alias of going to the upper directory.

I used to enjoy this feature all the time in `zsh` shell. I don't see there is any reason for my dear fish not having it.

