### PR TITLE
fix db pkg entries pointing away from core plugins

### DIFF
--- a/db/pkg/gi
+++ b/db/pkg/gi
@@ -1,1 +1,1 @@
-https://github.com/fishery/gi
+https://github.com/oh-my-fish/plugin-gi

--- a/db/pkg/tiny
+++ b/db/pkg/tiny
@@ -1,1 +1,1 @@
-https://github.com/fishery/tiny
+https://github.com/oh-my-fish/plugin-tiny


### PR DESCRIPTION
Fix for #404

A couple of db pkg entries were pointing to fishery rather than the core plugins.