### PR TITLE
Pure theme screenshot fixed to theme git repo screenshot

### DIFF
--- a/docs/Themes.md
+++ b/docs/Themes.md
@@ -1709,7 +1709,7 @@ This is similar to godfat's gitstatus theme, but mainly includes red, white, cya
 #### Screenshot
 
 <p align="center">
-<img width="572" src="screenshot.png">
+<img width="572" src="https://github.com/sindresorhus/pure/blob/master/screenshot.png?raw=true">
 </p>
 
 #### Install


### PR DESCRIPTION
I noticed the screenshot was going to a non existent screenshot file, so I redirected it to the screenshot provided in the original git repo for the Pure theme.
