### PR TITLE
Make OMF command colors independent of Fish version

### DIFF
--- a/pkg/omf/functions/core/omf.core.update.fish
+++ b/pkg/omf/functions/core/omf.core.update.fish
@@ -4,10 +4,10 @@ function omf.core.update
     # If the channel isn't explicitly set and we are currently tracking a branch instead of a version, the user probably
     # upgraded from an old version. Let them know that we will start updating to stable versions.
     if begin; not test -f $OMF_CONFIG/channel; and command git -C "$OMF_PATH" symbolic-ref -q HEAD > /dev/null; end
-      set_color $fish_color_quote ^/dev/null; or set_color yellow --bold
+      set_color yellow --bold ^ /dev/null
       echo ">> You have been switched to the stable release channel of Oh My Fish."
       echo ">> To switch back to the development channel, run `omf channel dev`."
-      set_color normal
+      set_color normal ^ /dev/null
     end
 
     # Determine the remote to fetch from.

--- a/pkg/omf/init.fish
+++ b/pkg/omf/init.fish
@@ -4,23 +4,23 @@ set -g OMF_INVALID_ARG   3
 set -g OMF_UNKNOWN_ERR   4
 
 function omf::em
-  set_color $fish_color_match ^/dev/null; or set_color cyan
+  set_color cyan ^ /dev/null
 end
 
 function omf::dim
-  set_color $fish_color_autosuggestion ^/dev/null; or set_color 555
+  set_color 555 ^ /dev/null
 end
 
 function omf::err
-  set_color $fish_color_error ^/dev/null; or set_color red --bold
+  set_color red --bold ^ /dev/null
 end
 
 function omf::under
-  set_color --underline
+  set_color --underline ^ /dev/null
 end
 
 function omf::off
-  set_color normal
+  set_color normal ^ /dev/null
 end
 
 autoload $path/functions/{compat,core,packages,themes,bundle,util,repo,cli,search}


### PR DESCRIPTION
Partially fixes #440. Use specific colors instead of using whatever colors are set for Fish's internal use, which could change (and did in 2.4.0).