### PR TITLE
Add the Project Jump plugin

### DIFF
--- a/db/pkg/pj
+++ b/db/pkg/pj
@@ -1,0 +1,1 @@
+https://github.com/oh-my-fish/plugin-pj.git


### PR DESCRIPTION
This PR adds a new plugin, which is a port of the oh-my-zsh `pj` plugin.

See this repository for details

https://github.com/esphen/plugin-pj