### PR TITLE
Print some useful diagnostic info in `omf doctor`

### DIFF
--- a/pkg/omf/functions/core/omf.doctor.fish
+++ b/pkg/omf/functions/core/omf.doctor.fish
@@ -46,6 +46,12 @@ function __omf.doctor.git_version
 end
 
 function omf.doctor
+  echo "Oh My Fish version:   "(omf.version)
+  echo "OS type:              "(uname)
+  echo "Fish version:         "(fish --version)
+  echo "Git version:          "(git --version)
+  echo "Git core.autocrlf:    "(git config core.autocrlf; or echo no)
+
   __omf.doctor.fish_version; or set -l doctor_failed
   __omf.doctor.git_version; or set -l doctor_failed
   __omf.doctor.theme; or set -l doctor_failed


### PR DESCRIPTION
Since there are some common things we need to know when troubleshooting OMF, this adds some relevant diagnostic information so far as output to the `omf doctor` command. We can then recommend users simply paste the output of `omf doctor` as long as it is accessible, or literal `omf.doctor` otherwise.

This does not aid troubleshooting the installation process itself. It might be useful to separate the doctor into its own script that can be downloaded and used separately.