### PR TITLE
Ensure Fish scripts always use LF line endings, otherwise multiline commands break

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure Fish scripts always use LF line endings, otherwise multiline commands break.
+*.fish text eol=lf


### PR DESCRIPTION
Force all Fish scripts in this repo to be checked out using LF line endings.

Prevents problems documented in issues #217, #379, and #444.