### PR TITLE
Normalize redirection syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ohmyfish/fish:2.3.1
+FROM ohmyfish/fish:2.4.0
 
 COPY . /src/oh-my-fish
 

--- a/bin/install
+++ b/bin/install
@@ -394,7 +394,7 @@ function backup_file -a file_path
   say "Existent $file found at $path"
   say "↳ Moving to $backup_file"
 
-  if not command cp "$file_path" $backup_file 2>/dev/null
+  if not command cp "$file_path" $backup_file ^/dev/null
     abort "Could not backup $file_path"
   end
 

--- a/lib/autoload.fish
+++ b/lib/autoload.fish
@@ -3,14 +3,14 @@ function autoload
   case '-e' '--erase'
     test (count $argv) -ge 2
       and __autoload_erase $argv[2..-1]
-      or echo "usage: autoload $argv[1] <path>..." 1>&2
+      or echo "usage: autoload $argv[1] <path>..." >&2
   case "-*" "--*"
     echo "autoload: invalid option $argv[1]"
     return 1
   case '*'
     test (count $argv) -ge 1
       and __autoload_insert $argv
-      or echo "usage: autoload <path>..." 1>&2
+      or echo "usage: autoload <path>..." >&2
   end
 end
 function __autoload_insert

--- a/pkg/omf/functions/bundle/omf.bundle.add.fish
+++ b/pkg/omf/functions/bundle/omf.bundle.add.fish
@@ -8,7 +8,7 @@ function omf.bundle.add -a type name_or_url
   set -l record "$type $name_or_url"
 
   if test -f $bundle
-    if not grep $record $bundle > /dev/null 2>&1
+    if not grep $record $bundle > /dev/null ^&1
       echo $record >> $bundle
     end
   else

--- a/pkg/omf/functions/cli/omf.cli.channel.fish
+++ b/pkg/omf/functions/cli/omf.cli.channel.fish
@@ -7,7 +7,7 @@ function omf.cli.channel
       omf.channel.set $argv
 
     case '*'
-      echo (omf::err)"Invalid number of arguments"(omf::off) 1^&2
+      echo (omf::err)"Invalid number of arguments"(omf::off) >&2
       omf help channel
       return $OMF_INVALID_ARG
   end

--- a/pkg/omf/functions/cli/omf.cli.install.fish
+++ b/pkg/omf/functions/cli/omf.cli.install.fish
@@ -1,5 +1,6 @@
 function omf.cli.install
   set fail_count 0
+  echo hi
 
   switch (count $argv)
   case 0

--- a/pkg/omf/functions/cli/omf.cli.new.fish
+++ b/pkg/omf/functions/cli/omf.cli.new.fish
@@ -1,7 +1,7 @@
 function omf.cli.new
   if test (count $argv) -ne 2
-    echo (omf::err)"Package type or name missing"(omf::off) 1^&2
-    echo "Usage: omf new "(omf::em)"(pkg | theme)"(omf::off)" <name>" 1^&2
+    echo (omf::err)"Package type or name missing"(omf::off) >&2
+    echo "Usage: omf new "(omf::em)"(pkg | theme)"(omf::off)" <name>" >&2
     return $OMF_MISSING_ARG
   end
   omf.packages.new $argv

--- a/pkg/omf/functions/cli/omf.cli.remove.fish
+++ b/pkg/omf/functions/cli/omf.cli.remove.fish
@@ -11,16 +11,16 @@ function omf.cli.remove -a name
       set -q OMF_AUTO_RELOAD
         and omf.cli.reload
     case 1
-      echo (omf::err)"$name could not be removed."(omf::off) 1^&2
+      echo (omf::err)"$name could not be removed."(omf::off) >&2
     case 2
-      echo (omf::err)"$name could not be found."(omf::off) 1^&2
+      echo (omf::err)"$name could not be found."(omf::off) >&2
     end
 
     return $code
 
   case '*'
-    echo (omf::err)"Invalid number of arguments"(omf::off) 1^&2
-    echo "Usage: omf remove "(omf::em)"<name>"(omf::off) 1^&2
+    echo (omf::err)"Invalid number of arguments"(omf::off) >&2
+    echo "Usage: omf remove "(omf::em)"<name>"(omf::off) >&2
     return $OMF_INVALID_ARG
   end
 end

--- a/pkg/omf/functions/cli/omf.cli.submit.fish
+++ b/pkg/omf/functions/cli/omf.cli.submit.fish
@@ -3,8 +3,8 @@ function omf.cli.submit
   case 2
     omf.packages.submit $argv
   case "*"
-    echo (omf::err)"Argument missing"(omf::off) 1^&2
-    echo "Usage: $_ "(omf::em)"submit"(omf::off)" "(omf::em)"pkg|themes"(omf::off)"/<name> <url>" 1^&2
+    echo (omf::err)"Argument missing"(omf::off) >&2
+    echo "Usage: $_ "(omf::em)"submit"(omf::off)" "(omf::em)"pkg|themes"(omf::off)"/<name> <url>" >&2
     return $OMF_MISSING_ARG
   end
 end

--- a/pkg/omf/functions/cli/omf.cli.theme.fish
+++ b/pkg/omf/functions/cli/omf.cli.theme.fish
@@ -5,8 +5,8 @@ function omf.cli.theme -a name
   case 1
     omf.theme.set $name
   case '*'
-    echo (omf::err)"Invalid number of arguments"(omf::off) 1^&2
-    echo "Usage: $_ "(omf::em)"$argv[1]"(omf::off)" [<theme name>]" 1^&2
+    echo (omf::err)"Invalid number of arguments"(omf::off) >&2
+    echo "Usage: $_ "(omf::em)"$argv[1]"(omf::off)" [<theme name>]" >&2
     return $OMF_INVALID_ARG
   end
 end

--- a/pkg/omf/functions/core/omf.channel.set.fish
+++ b/pkg/omf/functions/core/omf.channel.set.fish
@@ -1,7 +1,7 @@
 function omf.channel.set -a name
   # If an argument is specified, set the update channel.
   if begin; test -z "$name"; or not contains -- $name stable dev; end
-    echo (omf::err)"'$name' is not a valid channel."(omf::off) 1^&2
+    echo (omf::err)"'$name' is not a valid channel."(omf::off) >&2
     return 1
   end
 

--- a/pkg/omf/functions/omf.fish
+++ b/pkg/omf/functions/omf.fish
@@ -74,7 +74,7 @@ function omf -d "Oh My Fish"
       omf.cli.version $arguments
 
     case "*"
-      echo (omf::err)"$argv[1] option not recognized"(omf::off) 1^&2
+      echo (omf::err)"$argv[1] option not recognized"(omf::off) >&2
       return $OMF_UNKNOWN_OPT
   end
 end

--- a/pkg/omf/functions/packages/omf.packages.cd.fish
+++ b/pkg/omf/functions/packages/omf.packages.cd.fish
@@ -17,6 +17,6 @@ function omf.packages.cd -a name -d "Change the current working directory to plu
     end
   end
 
-  echo (omf::err)"$name is not a valid package/theme name"(omf::off) 1^&2
+  echo (omf::err)"$name is not a valid package/theme name"(omf::off) >&2
   return $OMF_INVALID_ARG
 end

--- a/pkg/omf/functions/packages/omf.packages.describe.fish
+++ b/pkg/omf/functions/packages/omf.packages.describe.fish
@@ -9,9 +9,9 @@ function omf.packages.describe -a name
     if test -e $package_path
       set url (cat $package_path)
       set repo (basename (dirname $url))/(basename $url)
-      curl -s https://api.github.com/repos/$repo 2>/dev/null | grep \"description\" | head -1 | cut -d':' -f2- | sed -e 's/["|,]//g;s/^[ \t]//g'
+      curl -s https://api.github.com/repos/$repo ^/dev/null | grep \"description\" | head -1 | cut -d':' -f2- | sed -e 's/["|,]//g;s/^[ \t]//g'
     else
-      echo (omf::err)"$name is not a valid pkg."(omf::off) 1^&2
+      echo (omf::err)"$name is not a valid pkg."(omf::off) >&2
       return $OMF_INVALID_ARG
     end
   end

--- a/pkg/omf/functions/packages/omf.packages.install.fish
+++ b/pkg/omf/functions/packages/omf.packages.install.fish
@@ -3,11 +3,11 @@ function __omf.packages.install.success
 end
 
 function __omf.packages.install.error
-  echo (omf::err)"Could not install $argv."(omf::off) 1^&2
+  echo (omf::err)"Could not install $argv."(omf::off) >&2
 end
 
 function __omf.packages.install.error.already
-  echo (omf::err)"Error: $argv already installed."(omf::off) 1^&2
+  echo (omf::err)"Error: $argv already installed."(omf::off) >&2
 end
 
 function omf.packages.install -a name_or_url

--- a/pkg/omf/functions/packages/omf.packages.new.fish
+++ b/pkg/omf/functions/packages/omf.packages.new.fish
@@ -34,7 +34,7 @@ function __omf.packages.new.from_template -a path github user name
       end)$target
     end
   end
-  popd >/dev/null ^&2
+  popd >/dev/null ^&1
 end
 
 
@@ -45,12 +45,12 @@ function omf.packages.new -a option name
     case "t" "th" "the" "thm" "theme" "themes"
       set option "themes"
     case "*"
-      echo (omf::err)"$option is not a valid option."(omf::off) 1^&2
+      echo (omf::err)"$option is not a valid option."(omf::off) >&2
       return $OMF_INVALID_ARG
   end
 
   if not omf.packages.valid_name "$name"
-    echo (omf::err)"$name is not a valid package/theme name"(omf::off) 1^&2
+    echo (omf::err)"$name is not a valid package/theme name"(omf::off) >&2
     return $OMF_INVALID_ARG
   end
 
@@ -72,7 +72,7 @@ function omf.packages.new -a option name
       omf.theme.set $name
     end
   else
-    echo (omf::err)"\$OMF_CONFIG and/or \$OMF_PATH undefined."(omf::off) 1^&2
+    echo (omf::err)"\$OMF_CONFIG and/or \$OMF_PATH undefined."(omf::off) >&2
     exit $OMF_UNKNOWN_ERR
   end
 end

--- a/pkg/omf/functions/packages/omf.packages.remove.fish
+++ b/pkg/omf/functions/packages/omf.packages.remove.fish
@@ -1,12 +1,12 @@
 function omf.packages.remove -a pkg
 
   if not omf.packages.valid_name $pkg
-    echo (omf::err)"$pkg is not a valid package/theme name"(omf::off) 1>&2
+    echo (omf::err)"$pkg is not a valid package/theme name"(omf::off) >&2
     return $OMF_INVALID_ARG
   end
 
   if test $pkg = "omf" -o $pkg = "default"
-    echo (omf::err)"You can't remove `$pkg`"(omf::off) 1>&2
+    echo (omf::err)"You can't remove `$pkg`"(omf::off) >&2
     return $OMF_INVALID_ARG
   end
 

--- a/pkg/omf/functions/packages/omf.packages.submit.fish
+++ b/pkg/omf/functions/packages/omf.packages.submit.fish
@@ -10,27 +10,27 @@ function omf.packages.submit -a name url -d "Submit a package to the registry"
     case pkg
     case themes
     case "*"
-      echo (omf::err)"Missing directory name: pkg/ or themes/"(omf::off) 1^&2
+      echo (omf::err)"Missing directory name: pkg/ or themes/"(omf::off) >&2
       return $OMF_INVALID_ARG
   end
 
   set -l pkg (basename $name)
   if not omf.packages.valid_name $pkg
-    echo (omf::err)"$pkg is not a valid package/theme name"(omf::off) 1^&2
+    echo (omf::err)"$pkg is not a valid package/theme name"(omf::off) >&2
     return $OMF_INVALID_ARG
   end
 
   if test -z "$url"
-    echo (omf::em)"URL not specified, looking for a remote origin..."(omf::off) 1^&2
+    echo (omf::em)"URL not specified, looking for a remote origin..."(omf::off) >&2
     set url (git config --get remote.origin.url)
     if test -z "$url"
-      echo (omf::em)"$pkg remote URL not found"(omf::off) 1^&2
-      echo "Try: git remote add <URL> or see Docs#Submitting" 1^&2
+      echo (omf::em)"$pkg remote URL not found"(omf::off) >&2
+      echo "Try: git remote add <URL> or see Docs#Submitting" >&2
       return $OMF_INVALID_ARG
     end
   else
     if test -e "$OMF_PATH/db/$name"
-      echo (omf::err)"Error: $pkg already exists in the registry!"(omf::off) 1^&2
+      echo (omf::err)"Error: $pkg already exists in the registry!"(omf::off) >&2
       return $OMF_INVALID_ARG
     else
       echo "$url" > $OMF_PATH/db/$name

--- a/pkg/omf/functions/packages/omf.packages.update.fish
+++ b/pkg/omf/functions/packages/omf.packages.update.fish
@@ -1,6 +1,6 @@
 function omf.packages.update -a name
   if not set target_path (omf.packages.path $name)
-    echo (omf::err)"Could not find $name."(omf::off) 1>&2
+    echo (omf::err)"Could not find $name."(omf::off) >&2
     return 1
   end
 
@@ -12,7 +12,7 @@ function omf.packages.update -a name
         omf.bundle.install $target_path/bundle
         set result (omf::em)"$name successfully updated."(omf::off)
       case 1
-        echo (omf::err)"Could not update $name."(omf::off) 1>&2
+        echo (omf::err)"Could not update $name."(omf::off) >&2
         return 1
       case 2
         set result (omf::dim)"$name is already up-to-date."(omf::off)
@@ -21,7 +21,7 @@ function omf.packages.update -a name
 
   # Run update hook.
   if not omf.packages.run_hook $target_path update
-    echo (omf::err)"Could not update $name."(omf::off) 1^&2
+    echo (omf::err)"Could not update $name."(omf::off) >&2
     return 1
   end
 

--- a/pkg/omf/functions/repo/omf.repo.pull.fish
+++ b/pkg/omf/functions/repo/omf.repo.pull.fish
@@ -1,7 +1,7 @@
 function omf.repo.pull
 
   if test (count $argv) -eq 0
-    echo (omf::err)"omf.repo.pull takes a repository path as an argument."(omf::off) 1>&2
+    echo (omf::err)"omf.repo.pull takes a repository path as an argument."(omf::off) >&2
     return $OMF_MISSING_ARG
   end
 

--- a/pkg/omf/omf.update.fish
+++ b/pkg/omf/omf.update.fish
@@ -4,7 +4,7 @@ function omf.update -a name
   end
 
   function __omf.update.error
-    echo (omf::err)"Could not update $argv."(omf::off) 1^&2
+    echo (omf::err)"Could not update $argv."(omf::off) >&2
   end
 
   if test \( -e $OMF_PATH/themes/$name \) -o \( -e $OMF_CONFIG/themes/$name \)

--- a/tools/generate-themes-doc.fish
+++ b/tools/generate-themes-doc.fish
@@ -46,7 +46,7 @@ for theme in (command find $project_dir/db/themes/ -type f|sort)
     echo "Fetching readme for $name"
     __write_theme_readme $name $raw_content $readme
   else
-    echo "FAILED: No readme for $name" 1>&2
+    echo "FAILED: No readme for $name" >&2
     echo "See $url for details" >> $temp_theme_contents
   end
 end

--- a/tools/travis-github-pr-integration.sh
+++ b/tools/travis-github-pr-integration.sh
@@ -6,7 +6,7 @@ if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then
 fi
 
 GITHUB_PR_URL=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
-GITHUB_PR_BODY=$(curl -s $GITHUB_PR_URL 2>/dev/null)
+GITHUB_PR_BODY=$(curl -s $GITHUB_PR_URL ^/dev/null)
 
 if [[ $GITHUB_PR_BODY =~ \"ref\":\ *\"([a-zA-Z0-9_-]*)\" ]]; then
   export OMF_REPO_BRANCH=${BASH_REMATCH[1]}


### PR DESCRIPTION
Fixes a problem with redirection syntax for Fish >=2.4.0 observed in #454. All redirections are normalized to the correct syntax.

Also bump Fish version in Docker image for better catching of these issues.