### PR TITLE
Get oh-my-fish installer from a secure connection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Oh My Fish provides core infrastructure to allow you to install packages which e
 You can get started right away with the default setup by running this in your terminal:
 
 ```fish
-curl -L http://get.oh-my.fish | fish
+curl -L https://get.oh-my.fish | fish
 ```
 
 This will download the installer script and start the installation. Alternatively, you can download the installer and customize your install:
 
 ```fish
-curl -L http://get.oh-my.fish > install
+curl -L https://get.oh-my.fish > install
 fish install --path=~/.local/share/omf --config=~/.config/omf
 ```
 
@@ -38,7 +38,7 @@ $ git clone https://github.com/oh-my-fish/oh-my-fish
 $ cd oh-my-fish
 $ bin/install --offline
 # with a tarball
-$ curl -L http://get.oh-my.fish > install
+$ curl -L https://get.oh-my.fish > install
 $ fish install --offline=omf.tar.gz
 ```
 


### PR DESCRIPTION
Use HTTPS schema instead of cleartext HTTP.
SSL certificate provided by letsencrypt.com, installed on private nginx server for redirection.

Moving to the private server should solve the issue with NameCheap's URL redirection service that didn't behave so well lately (see: #478, #489).
The move to HTTPS is a reasonable and meaningful step towards a safer environment for OMF users (see discussion in #482).