### PR TITLE
Detect themes by fish_prompt instead of name

### DIFF
--- a/pkg/omf/functions/packages/omf.packages.install.fish
+++ b/pkg/omf/functions/packages/omf.packages.install.fish
@@ -37,7 +37,7 @@ function omf.packages.install -a name_or_url
 
   # If we don't know the package type yet, check if the package is a theme.
   if not set -q package_type
-    echo $url | grep -q theme-
+    test -f $install_dir/fish_prompt.fish
       and set package_type theme
       or set package_type plugin
   end


### PR DESCRIPTION
When installing a package from outside a repository, we currently need to detect if it is a theme or package. We were doing this by checking for a `theme-` prefix, but this enforces repo names on package authors and is too restrictive. Instead, detect a theme by checking for the presence of a `fish_prompt.fish` file, which should be much more reliable.

Fixes #191.