### PR TITLE
Limit search to name+description

### DIFF
--- a/pkg/omf/functions/index/omf.index.query.fish
+++ b/pkg/omf/functions/index/omf.index.query.fish
@@ -73,7 +73,7 @@ function omf.index.query -d 'Query packages in the index'
         type_matches = 1;
       }
 
-      !text_matches && !/^#/ {
+      !text_matches && !/^#/ && $1 == "description" {
         if (match(tolower($2), q_text)) {
           text_matches = 1;
         }


### PR DESCRIPTION
Full text search outside of name and description seems to make the search _less_ useful. For example, searching for "git" returns every possible package, because they all have "github" in the repo URL. Similarly searching for other fields seems to reduce the usefulness of the results.

This tightens up the search by applying full text search queries to only the package name and description.