### PR TITLE
Update README.md to reflect length of list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ For more information check the [FAQ](docs/en-US/FAQ.md#what-does-oh-my-fish-do-e
 ### Dotfiles
 
 The `$OMF_CONFIG` directory represents the user state of Oh My Fish. It is the perfect
-candidate for being added to your dotfiles and/or checked out to version control. There are four important files:
+candidate for being added to your dotfiles and/or checked out to version control. There are five important files:
 
 - __`theme`__ - The current theme
 - __`bundle`__ - List of currently installed packages/themes


### PR DESCRIPTION
Hi! I was about to install oh-my-fish for the first time and saw this discrepancy in the README. The introduction to the list had four items, but the list itself has five items.