### PR TITLE
Typo: Update example to use correct command

### DIFF
--- a/docs/en-US/Packages.md
+++ b/docs/en-US/Packages.md
@@ -17,7 +17,7 @@ To learn package creation let's create a new package that will provide a `hello_
 Oh My Fish can scaffold a package structure for you. Use the command `omf new`:
 
 ```fish
-$ omf new pkg hello_world
+$ omf new plugin hello_world
 ```
 
 > Use `omf new theme my_theme_name` for themes.


### PR DESCRIPTION
When creating new plugins the word 'pkg' does not exist for 'omf new' command.
The correct one is 'omf new plugin'.

I am creating a omf plugin and saw that issue/typo at the documentation. 
It is a simple contribution.