### PR TITLE
Fix 'omf new' year in LICENSE files

### DIFF
--- a/pkg/omf/functions/packages/omf.packages.new.fish
+++ b/pkg/omf/functions/packages/omf.packages.new.fish
@@ -23,7 +23,7 @@ function __omf.packages.new.from_template -a path github user name
           echo (basename "$file")
         end
       end)
-	  set -l year (date +%Y)
+      set -l year (date +%Y)
       sed "s/{{USER_NAME}}/$user/;s/{{GITHUB_USER}}/$github/;s/{{NAME}}/$name/;s/{{YEAR}}/$year/" \
         $file > $target
       echo (omf::em)" create "(omf::off)" "(begin

--- a/pkg/omf/functions/packages/omf.packages.new.fish
+++ b/pkg/omf/functions/packages/omf.packages.new.fish
@@ -23,7 +23,8 @@ function __omf.packages.new.from_template -a path github user name
           echo (basename "$file")
         end
       end)
-      sed "s/{{USER_NAME}}/$user/;s/{{GITHUB_USER}}/$github/;s/{{NAME}}/$name/;s/{{YEAR}}/${date +%y}/" \
+	  set -l year (date +%Y)
+      sed "s/{{USER_NAME}}/$user/;s/{{GITHUB_USER}}/$github/;s/{{NAME}}/$name/;s/{{YEAR}}/$year/" \
         $file > $target
       echo (omf::em)" create "(omf::off)" "(begin
         if test (basename $PWD) = $name

--- a/pkg/omf/functions/packages/omf.packages.new.fish
+++ b/pkg/omf/functions/packages/omf.packages.new.fish
@@ -23,7 +23,7 @@ function __omf.packages.new.from_template -a path github user name
           echo (basename "$file")
         end
       end)
-      sed "s/{{USER_NAME}}/$user/;s/{{GITHUB_USER}}/$github/;s/{{NAME}}/$name/" \
+      sed "s/{{USER_NAME}}/$user/;s/{{GITHUB_USER}}/$github/;s/{{NAME}}/$name/;s/{{YEAR}}/${date +%y}/" \
         $file > $target
       echo (omf::em)" create "(omf::off)" "(begin
         if test (basename $PWD) = $name

--- a/pkg/omf/templates/pkg/LICENSE
+++ b/pkg/omf/templates/pkg/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 {{USER_NAME}}
+Copyright (c) {{YEAR}} {{USER_NAME}}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/omf/templates/themes/LICENSE
+++ b/pkg/omf/templates/themes/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 {{USER_NAME}}
+Copyright (c) {{YEAR}} {{USER_NAME}}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This changes the [themes] and [pkg] LICENSE files to use a dynamic `year` variable.

The year is calculated using `set -l year (date +%Y)`.

Fixes #593.

[themes]: https://github.com/pxgamer/oh-my-fish/blob/feature/fix-omf-new-year/pkg/omf/templates/themes/LICENSE
[pkg]: https://github.com/pxgamer/oh-my-fish/blob/feature/fix-omf-new-year/pkg/omf/templates/pkg/LICENSE