### PR TITLE
Remove occurrences of `?` as a glob

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -29,7 +29,7 @@ function main
   # Parse command args
   while set -q argv[1]
     switch "$argv[1]"
-      case --help -h '/?'
+      case --help -h
         echo "Usage: install [options]
   Install Oh My Fish
 

--- a/init.fish
+++ b/init.fish
@@ -33,9 +33,9 @@ function fish_user_key_bindings
     and read -l theme < $OMF_CONFIG/theme
     or set -l theme default
   # Prepare packages key bindings paths
-  set -l key_bindings $OMF_CONFIG/key_binding?.fish \
+  set -l key_bindings $OMF_CONFIG/key_binding*.fish \
                       {$OMF_CONFIG,$OMF_PATH}/pkg/*/key_bindings.fish \
-                      {$OMF_CONFIG,$OMF_PATH}/themes/$theme/key_binding?.fish
+                      {$OMF_CONFIG,$OMF_PATH}/themes*/$theme/key_binding.fish
   # Source all keybindings collected
   for file in $key_bindings
     source $file

--- a/init.fish
+++ b/init.fish
@@ -32,10 +32,11 @@ function fish_user_key_bindings
   test -f $OMF_CONFIG/theme
     and read -l theme < $OMF_CONFIG/theme
     or set -l theme default
+  test -e $OMF_CONFIG/key_bindings.fish;
+    and source $OMF_CONFIG/key_bindings.fish
   # Prepare packages key bindings paths
-  set -l key_bindings $OMF_CONFIG/key_binding*.fish \
-                      {$OMF_CONFIG,$OMF_PATH}/pkg/*/key_bindings.fish \
-                      {$OMF_CONFIG,$OMF_PATH}/themes*/$theme/key_binding.fish
+  set -l key_bindings {$OMF_CONFIG,$OMF_PATH}/pkg/*/key_bindings.fish \
+                      {$OMF_CONFIG,$OMF_PATH}/themes*/$theme/key_bindings.fish
   # Source all keybindings collected
   for file in $key_bindings
     source $file

--- a/pkg/omf/functions/index/omf.index.query.fish
+++ b/pkg/omf/functions/index/omf.index.query.fish
@@ -12,10 +12,10 @@ function omf.index.query -d 'Query packages in the index'
         set q_type plugin
       case '--type=theme'
         set q_type theme
-      case '--name=?*'
+      case '--name=*'
         set -l IFS '='
         echo "$arg" | read dummy q_name
-      case '--text=?*'
+      case '--text=*'
         set -l IFS '='
         echo "$arg" | read dummy q_text
       case '*'

--- a/pkg/omf/functions/omf.fish
+++ b/pkg/omf/functions/omf.fish
@@ -2,13 +2,13 @@ function omf -d "Oh My Fish"
   # Parse any options before the command name.
   while set -q argv[1]
     switch $argv[1]
-      case '-h' '--help' '-\?' '/\?'
+      case '-h' '--help'
         set command help
 
       case '-v' '--version'
         set command version
 
-      case '-?*'
+      case '-*'
         echo (omf::err)"Unknown option: $argv[1]"(omf::off) >&2
         return $OMF_UNKNOWN_OPT
 
@@ -21,7 +21,7 @@ function omf -d "Oh My Fish"
 
   # Also extract a help flag from the last argument.
   switch "$argv[-1]"
-    case '-h' '--help' '-\?' '/\?'
+    case '-h' '--help'
       set command help
       set -e argv[-1]
   end

--- a/pkg/omf/functions/themes/omf.theme.set.fish
+++ b/pkg/omf/functions/themes/omf.theme.set.fish
@@ -34,7 +34,7 @@ function omf.theme.set -a target_theme
 
   # Reload fish key bindings if reload is available and needed
   functions -q __fish_reload_key_bindings
-    and test (count {$OMF_CONFIG,$OMF_PATH}/key_binding?.fish) -gt 0
+    and test (count {$OMF_CONFIG,$OMF_PATH}/key_binding*.fish) -gt 0
     and __fish_reload_key_bindings
 
   # Persist the changes

--- a/pkg/omf/functions/themes/omf.theme.set.fish
+++ b/pkg/omf/functions/themes/omf.theme.set.fish
@@ -34,7 +34,7 @@ function omf.theme.set -a target_theme
 
   # Reload fish key bindings if reload is available and needed
   functions -q __fish_reload_key_bindings
-    and test (count {$OMF_CONFIG,$OMF_PATH}/key_binding*.fish) -gt 0
+    and test -e $OMF_CONFIG/key_bindings.fish -o -e $OMF_PATH/key_bindings.fish
     and __fish_reload_key_bindings
 
   # Persist the changes


### PR DESCRIPTION
Since Fish Shell 3.0 [1], `?` as a glob is deprecated. Fixes #644

  1. https://github.com/fish-shell/fish-shell/releases/tag/3.0.0