### PR TITLE
Add branch information for install and update package

### DIFF
--- a/pkg/omf/functions/packages/omf.packages.install.fish
+++ b/pkg/omf/functions/packages/omf.packages.install.fish
@@ -11,10 +11,14 @@ function __omf.packages.install.error.already
 end
 
 function omf.packages.install -a name_or_url
-  if set -l props (omf.index.stat $name_or_url type repository)
+  if set -l props (omf.index.stat $name_or_url type repository branch)
     set package_type $props[1]
     set name $name_or_url
     set url $props[2]
+    set branch $props[3]
+    if test -z "$branch"
+      set branch "master"
+    end
   else
     set name (omf.packages.name $name_or_url)
     set url $name_or_url
@@ -30,7 +34,7 @@ function omf.packages.install -a name_or_url
   set -l install_dir $OMF_PATH/pkg/$name
 
   # Clone the package repository.
-  if not omf.repo.clone $url $install_dir
+  if not omf.repo.clone $url $branch $install_dir
     __omf.packages.install.error "$name"
     return $OMF_UNKNOWN_ERR
   end

--- a/pkg/omf/functions/packages/omf.packages.update.fish
+++ b/pkg/omf/functions/packages/omf.packages.update.fish
@@ -13,7 +13,7 @@ function omf.packages.update -a name
 
   # Only pull packages in version control
   if test -e $target_path/.git
-    omf.repo.pull $target_path $branch
+    omf.repo.pull $target_path "$branch"
     switch $status
       case 0
         omf.bundle.install $target_path/bundle

--- a/pkg/omf/functions/packages/omf.packages.update.fish
+++ b/pkg/omf/functions/packages/omf.packages.update.fish
@@ -1,4 +1,11 @@
 function omf.packages.update -a name
+  if set -l props (omf.index.stat $name branch)
+    set branch $props[1]
+    if test -z "$branch"
+      set branch "master"
+    end
+  end
+
   if not set target_path (omf.packages.path $name)
     echo (omf::err)"Could not find $name."(omf::off) >&2
     return 1
@@ -6,7 +13,7 @@ function omf.packages.update -a name
 
   # Only pull packages in version control
   if test -e $target_path/.git
-    omf.repo.pull $target_path
+    omf.repo.pull $target_path $branch
     switch $status
       case 0
         omf.bundle.install $target_path/bundle

--- a/pkg/omf/functions/repo/omf.repo.clone.fish
+++ b/pkg/omf/functions/repo/omf.repo.clone.fish
@@ -1,3 +1,3 @@
-function omf.repo.clone -a url path
-  command git clone --quiet $url $path
+function omf.repo.clone -a url branch path
+  command git clone --quiet $url -b $branch $path
 end

--- a/pkg/omf/functions/repo/omf.repo.pull.fish
+++ b/pkg/omf/functions/repo/omf.repo.pull.fish
@@ -1,11 +1,7 @@
-function omf.repo.pull
-
-  if test (count $argv) -eq 0
-    echo (omf::err)"omf.repo.pull takes a repository path as an argument."(omf::off) >&2
-    return $OMF_MISSING_ARG
+function omf.repo.pull -a repo_dir branch
+  if test -z "$branch"
+    set branch "master"
   end
-
-  set -l repo_dir $argv[1]
 
   function __omf.repo.git -V repo_dir
     command git -C "$repo_dir" $argv
@@ -21,12 +17,12 @@ function omf.repo.pull
   set initial_revision (__omf.repo.git rev-parse -q --verify HEAD);
     or return 1
 
-  # the refspec ensures that '$remote/master' gets updated
-  set -l refspec "refs/heads/master:refs/remotes/$remote/master"
+  # the refspec ensures that '$remote/$branch' gets updated
+  set -l refspec "refs/heads/$branch:refs/remotes/$remote/$branch"
   __omf.repo.git fetch --quiet $remote $refspec;
     or return 1
 
-  if test (__omf.repo.git rev-list --count master...FETCH_HEAD) -eq 0
+  if test (__omf.repo.git rev-list --count $branch...FETCH_HEAD) -eq 0
     return 2
   end
 
@@ -37,8 +33,8 @@ function omf.repo.pull
       and set stashed
   end
 
-  if test "$initial_branch" != master
-    __omf.repo.git checkout master --quiet
+  if test "$initial_branch" != $branch
+    __omf.repo.git checkout $branch --quiet
   end
 
   if not __omf.repo.git merge --ff-only --quiet FETCH_HEAD
@@ -48,7 +44,7 @@ function omf.repo.pull
     return 1
   end
 
-  if test "$initial_branch" != master
+  if test "$initial_branch" != $branch
     __omf.repo.git checkout $initial_branch --quiet
   end
 

--- a/pkg/omf/functions/repo/omf.repo.pull.fish
+++ b/pkg/omf/functions/repo/omf.repo.pull.fish
@@ -22,7 +22,7 @@ function omf.repo.pull -a repo_dir branch
   __omf.repo.git fetch --quiet $remote $refspec;
     or return 1
 
-  if test (__omf.repo.git rev-list --count $branch...FETCH_HEAD) -eq 0
+  if test (__omf.repo.git rev-list --count "$branch"...FETCH_HEAD) -eq 0
     return 2
   end
 
@@ -33,8 +33,8 @@ function omf.repo.pull -a repo_dir branch
       and set stashed
   end
 
-  if test "$initial_branch" != $branch
-    __omf.repo.git checkout $branch --quiet
+  if test "$initial_branch" != "$branch"
+    __omf.repo.git checkout "$branch" --quiet
   end
 
   if not __omf.repo.git merge --ff-only --quiet FETCH_HEAD
@@ -44,7 +44,7 @@ function omf.repo.pull -a repo_dir branch
     return 1
   end
 
-  if test "$initial_branch" != $branch
+  if test "$initial_branch" != "$branch"
     __omf.repo.git checkout $initial_branch --quiet
   end
 


### PR DESCRIPTION
See #678.

Find branch information in the repository first and then clone (or pull). If package doesn't have a branch attribute, `master` is used as the default branch.

Maybe more test is needed for it (especially for function `omf.repo.pull`). I only test them on several packages and themes and it works well, but I don't know wethear this project has some unit tests to go through.