### PR TITLE
lib/git/git_is_touched: Speed up

### DIFF
--- a/lib/git/git_is_touched.fish
+++ b/lib/git/git_is_touched.fish
@@ -1,5 +1,8 @@
 function git_is_touched -d "Check if repo has any changes"
   git_is_repo; and begin
-    test -n (echo (command git status --porcelain))
+    # The first checks for staged changes, the second for unstaged ones.
+    # We put them in this order because checking staged changes is *fast*.  
+    not command git diff-index --cached --quiet HEAD -- >/dev/null 2>&1
+    or command git diff --no-ext-diff --quiet --exit-code >/dev/null 2>&1
   end
 end

--- a/lib/git/git_is_touched.fish
+++ b/lib/git/git_is_touched.fish
@@ -3,6 +3,6 @@ function git_is_touched -d "Check if repo has any changes"
     # The first checks for staged changes, the second for unstaged ones.
     # We put them in this order because checking staged changes is *fast*.  
     not command git diff-index --cached --quiet HEAD -- >/dev/null 2>&1
-    or command git diff --no-ext-diff --quiet --exit-code >/dev/null 2>&1
+    or not command git diff --no-ext-diff --quiet --exit-code >/dev/null 2>&1
   end
 end


### PR DESCRIPTION
This used to use `git status --porcelain`, which by necessity needs to
check the entire repo for all kinds of changes, just to figure out if
there are any.

Instead, we now use git commands that can exit early.

In large repos, this can be faster by a factor of 15 or so.

Fixes #624.