### PR TITLE
Fix bogus math expression in basic_formatter

### DIFF
--- a/pkg/fish-spec/basic_formatter.fish
+++ b/pkg/fish-spec/basic_formatter.fish
@@ -4,7 +4,7 @@ end
 
 function __fish-spec.all_specs_finished -e all_specs_finished -a spec
   set -l __fish_spec_end_time (__fish-spec.current_time)
-  set -l diff (math "scale=3;($__fish_spec_end_time - $__fish_spec_start_time) / 1000")
+  set -l diff (math --scale=3 "($__fish_spec_end_time - $__fish_spec_start_time) / 1000")
 
   echo -en '\n\nFinished in '
   printf '%g' $diff


### PR DESCRIPTION
# Description

One math expression had a simple syntax error.

Fixes #704 

**Environment report**

<!--
Run the command `omf doctor` and paste the output here. Example:
-->

```
Oh My Fish version:   6
OS type:              Darwin
Fish version:         fish, version 3.0.2
Git version:          git version 2.21.0 Git version:          hub version 2.11.2
Git core.autocrlf:    no
Your shell is ready to swim.
```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation 
- [x] New and existing tests pass locally with my changes
