### PR TITLE
Add missing quotation marks in autoloader

### DIFF
--- a/lib/autoload.fish
+++ b/lib/autoload.fish
@@ -45,8 +45,8 @@ function __autoload_erase
       or  set function_indexes $function_indexes (contains -i $path $fish_function_path)
   end;
   test -n "$function_indexes"
-    and set -e fish_function_path[$function_indexes]
+    and set -e fish_function_path["$function_indexes"]
   test -n "$complete_indexes"
-    and set -e fish_complete_path[$complete_indexes]
+    and set -e fish_complete_path["$complete_indexes"]
   return 0
 end;


### PR DESCRIPTION
# Description

The auto loader lacked quotation marks around a variable. This PR fixes that and with this the bug described in #698. I tested it under both fish 2.7 and 3.0, that's also the reason why I'm attaching two environment reports.

Fixes #698 

**Environment report for fish 2.7**

```
Oh My Fish version:   6
OS type:              Linux
Fish version:         fish, version 2.7.1
Git version:          git version 2.11.0
Git core.autocrlf:    no
Your shell is ready to swim.
```

**Environment report for fish 3.0**

```
Oh My Fish version:   6
OS type:              Darwin
Fish version:         fish, version 3.0.2
Git version:          git version 2.21.0 Git version:          hub version 2.11.2
Git core.autocrlf:    no
Your shell is ready to swim.
```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes
