### PR TITLE
Enable conf.d loading for themes

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -48,4 +48,11 @@ end
 emit perf:timer:start "Oh My Fish init user config path"
 require --no-bundle --path $OMF_CONFIG
 emit perf:timer:finish "Oh My Fish init user config path"
+# Load conf.d for current theme if exists
+set -l theme_conf_d_path {$OMF_CONFIG,$OMF_PATH}/themes*/$theme/conf.d
+if test -d $theme_conf_d_path
+  for file in $theme_conf_d_path/*
+    source $file
+  end
+end
 emit perf:timer:finish "Oh My Fish initialisation"

--- a/init.fish
+++ b/init.fish
@@ -49,10 +49,8 @@ emit perf:timer:start "Oh My Fish init user config path"
 require --no-bundle --path $OMF_CONFIG
 emit perf:timer:finish "Oh My Fish init user config path"
 # Load conf.d for current theme if exists
-set -l theme_conf_d_path {$OMF_CONFIG,$OMF_PATH}/themes*/$theme/conf.d
-if test -d $theme_conf_d_path
-  for file in $theme_conf_d_path/*
-    source $file
-  end
+set -l theme_conf_path {$OMF_CONFIG,$OMF_PATH}/themes*/$theme/conf.d
+for conf in $theme_conf_path/*.fish
+  source $conf
 end
 emit perf:timer:finish "Oh My Fish initialisation"

--- a/pkg/omf/functions/themes/omf.theme.set.fish
+++ b/pkg/omf/functions/themes/omf.theme.set.fish
@@ -37,6 +37,11 @@ function omf.theme.set -a target_theme
     and test -e $OMF_CONFIG/key_bindings.fish -o -e $OMF_PATH/key_bindings.fish
     and __fish_reload_key_bindings
 
+  # Load target theme's conf.d files
+  for conf in {$OMF_CONFIG,$OMF_PATH}/themes/$target_theme/conf.d/*.fish
+    source $conf
+  end
+
   # Persist the changes
   echo "$target_theme" > "$OMF_CONFIG/theme"
 


### PR DESCRIPTION
# Description

This enables themes that have conf.d files to have those files loaded. Currently, only plugins have their conf.d file loaded, so themes that depend on their own conf.d can break, if no workarounds are used. The main theme where I encountered this problem is [pure](https://github.com/rafaelrinaldi/pure) which relies on its conf.d to do some setup (see rafaelrinaldi/pure#89).

Fixes #658 

## Changes
* Load conf.d snippets for the current theme on init (if the current theme has conf.d snippets)
* Load conf.d snippets for new theme on theme change

**Environment report**

<!--
Run the command `omf doctor` and paste the output here. Example:
-->

```
Oh My Fish version:   6
OS type:              Darwin
Fish version:         fish, version 3.0.2
Git version:          git version 2.22.0
Git core.autocrlf:    no
Your shell is ready to swim.
```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes 