### PR TITLE
Call the rm binary directly

### DIFF
--- a/pkg/omf/functions/bundle/omf.bundle.remove.fish
+++ b/pkg/omf/functions/bundle/omf.bundle.remove.fish
@@ -10,7 +10,7 @@ function omf.bundle.remove
       set name $argv[2]
       set bundle_contents (cat $bundle | sort -u)
 
-      rm -f $bundle
+      command rm -f $bundle
 
       for record in $bundle_contents
         set record_type (echo $record | cut -d' ' -f1)

--- a/pkg/omf/functions/packages/omf.packages.remove.fish
+++ b/pkg/omf/functions/packages/omf.packages.remove.fish
@@ -20,7 +20,7 @@ function omf.packages.remove -a pkg
     source $path/uninstall.fish 2> /dev/null;
       and emit uninstall_$pkg
 
-    if rm -rf $path
+    if command rm -rf $path
       omf.bundle.remove "package" $pkg
       return 0
     else
@@ -36,7 +36,7 @@ function omf.packages.remove -a pkg
     test $pkg = (cat $OMF_CONFIG/theme);
       and echo default > $OMF_CONFIG/theme
 
-    if rm -rf $path
+    if command rm -rf $path
       omf.bundle.remove "theme" $pkg
       return 0
     else


### PR DESCRIPTION
# Description

Call `command rm` instead of `rm` in `omf destroy` since `rm` may be aliased to something else and fail.

Fixes #717

**Environment report**

```
Oh My Fish version:   6
OS type:              Linux
Fish version:         fish, version 3.0.2
Git version:          git version 2.23.0
Git core.autocrlf:    no
Your shell is ready to swim.
```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code