### PR TITLE
Docs: Fix Markdown syntax (paragraphs)

### DIFF
--- a/docs/Themes.md
+++ b/docs/Themes.md
@@ -1248,17 +1248,17 @@ $ omf install es
 
 #### Screenshot
 
-#####__Git folder__
+##### __Git folder__
 <p align="center">
 <img src="https://github.com/oh-my-fish/theme-es/blob/master/Fish%20Prompt%20Git-es.png?raw=true">
 </p>
 
-#####__Normal folder (no Git)__
+##### __Normal folder (no Git)__
 <p align="center">
 <img src="https://github.com/oh-my-fish/theme-es/blob/master/Fish%20Prompt%20NoGit-es.png?raw=true">
 </p>
 
-#####__Normal read-only folder (no Git)__
+##### __Normal read-only folder (no Git)__
 <p align="left">
 <img src="https://github.com/oh-my-fish/theme-es/blob/master/Fish%20Prompt%20NoGit%20Read-only-es.png?raw=true" width="280">
 </p>
@@ -2833,9 +2833,7 @@ Zhishen Wen's simple fun theme =)
 ###### Left prompt
 User, host, abbreviated path, and git branch info
 
-######Right prompt
+###### Right prompt
 Time and exit code
 
 Enjoy!
-
-


### PR DESCRIPTION
# Description

Some paragraphs are rendered incorrectly in [Themes.md](./docs/Themes.md).
I fixed Markdown syntax by adding spaces after *#-paragraphs*

Fixes # N/A

**Environment report**
N/A

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation