### PR TITLE
fix one more caret error

### DIFF
--- a/tools/travis-github-pr-integration.sh
+++ b/tools/travis-github-pr-integration.sh
@@ -6,7 +6,7 @@ if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then
 fi
 
 GITHUB_PR_URL=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
-GITHUB_PR_BODY=$(curl -s $GITHUB_PR_URL ^/dev/null)
+GITHUB_PR_BODY=$(curl -s $GITHUB_PR_URL 2> /dev/null)
 
 if [[ $GITHUB_PR_BODY =~ \"ref\":\ *\"([a-zA-Z0-9_-]*)\" ]]; then
   export OMF_REPO_BRANCH=${BASH_REMATCH[1]}


### PR DESCRIPTION
# Description

Fixing one more error where we used a caret for IO redirection which is no longer valid

**Environment report**

```
Oh My Fish version:   6-48-g6e5cae8
OS type:              Darwin
Fish version:         fish, version 3.1.0
Git version:          git version 2.25.0 Git version:          hub version 2.14.1
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.
```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes