### PR TITLE
fix broken link in Themes.md

### DIFF
--- a/docs/Themes.md
+++ b/docs/Themes.md
@@ -47,7 +47,7 @@
 - [pastfish](#pastfish)
 - [perryh](#perryh)
 - [plain](#plain)
-- [pure](#pure)
+- [pure](#pure-----)
 - [red-snapper](#red-snapper)
 - [robbyrussell](#robbyrussell)
 - [scorphish](#scorphish)


### PR DESCRIPTION
fix the broken link

it is caused by https://github.com/oh-my-fish/oh-my-fish/pull/694

here is a simple check
* <https://github.com/oh-my-fish/oh-my-fish/blob/master/docs/Themes.md#pure>
* <https://github.com/oh-my-fish/oh-my-fish/blob/master/docs/Themes.md#pure----->