### PR TITLE
Fix double slash in index path

### DIFF
--- a/pkg/omf/functions/index/omf.index.path.fish
+++ b/pkg/omf/functions/index/omf.index.path.fish
@@ -1,5 +1,5 @@
 function omf.index.path -d 'Get the path to the local package index'
   set -q XDG_CACHE_HOME
-    and echo "$XDG_CACHE_HOME/omf"
-    or echo "$HOME/.cache/omf"
+    and echo (string trim -r -c "/" $XDG_CACHE_HOME)"/omf"
+    or echo (string trim -r -c "/" $HOME)"/.cache/omf"
 end

--- a/pkg/omf/functions/index/omf.index.path.fish
+++ b/pkg/omf/functions/index/omf.index.path.fish
@@ -1,5 +1,5 @@
 function omf.index.path -d 'Get the path to the local package index'
   set -q XDG_CACHE_HOME
-    and echo (string trim -r -c "/" $XDG_CACHE_HOME)"/omf"
-    or echo (string trim -r -c "/" $HOME)"/.cache/omf"
+    and echo (echo $XDG_CACHE_HOME | sed 's:/*$::')"/omf"
+    or echo (echo $HOME | sed 's:/*$::')"/.cache/omf"
 end


### PR DESCRIPTION
# Description
`XDG_*` or `HOME` variables might contains extra slash at the end of path (I don't know if this is against specification). This double slash might disturb comparison and make them false positive. The consequence is as described in the issue.

The error can happen at the first time OMF installed thus might block potential new user.

Fixes #774 

**Environment report**

```
Oh My Fish version:   7
OS type:              Linux
Fish version:         fish, version 3.0.2
Git version:          git version 2.25.4
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.

```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing tests pass locally with my changes <!--
remove next checkbox if you didn't change the install script -->
- [ ] I have updated the SHA256 checksum for the install script
