### PR TITLE
Update Easy Install instructions for lolfish theme

### DIFF
--- a/docs/Themes.md
+++ b/docs/Themes.md
@@ -1825,6 +1825,7 @@ Using [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish):
 
 ```Bash
 omf install lolfish
+cp ~/.local/share/omf/themes/lolfish/lol.fish ~/.local/share/omf/themes/lolfish/fish_prompt.fish
 ```
 ##### Less Easy Install
 


### PR DESCRIPTION
This commit will add a step to the "Easy Install" instructions of the `lolfish` theme.

`omf install lolfish` and `omf theme lolfish` are not enough for the `lolfish` theme to work.

Due to how `lolfish` only has a `lol.fish` file, the theme is not being recognized. Renaming this file to `fish_prompt.fish` allows for the theme to be turned on/off as usual using `omf theme <theme-name>`.

I have the command be `cp` so that the original `lol.fish` file is not lost in case other commands rely on it existing.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

**Environment report**

<!--
Run the command `omf doctor` and paste the output here. Example:
-->

```
Oh My Fish version:   7
OS type:              Darwin
Fish version:         fish, version 3.0.2
Git version:          git version 2.20.1 (Apple Git-117)
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.
```

# Checklist:

- [ ] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [X] I have performed a self-review of my own code
- [N/A ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] New and existing tests pass locally with my changes <!--
remove next checkbox if you didn't change the install script -->