### PR TITLE
Fix small typo

### DIFF
--- a/docs/Themes.md
+++ b/docs/Themes.md
@@ -1635,7 +1635,7 @@ set -g theme_display_jobs no
 set -g theme_display_jobs_always yes
 
 #### Hide the current directory read/write indicator.
-set -g theme_display_rwt no
+set -g theme_display_rw no
 
 #### Don't display the VirtualEnv prompt.
 set -g theme_display_virtualent no


### PR DESCRIPTION
# Description

Discovered while setting up the kawasaki theme, that there was a small typo in `Themes.md`. 
Found correction in the [kawasaki repo](https://github.com/hastinbe/theme-kawasaki/blob/e5c3a7c33485fe3fe28c66fd3dd924ac6c8eac98/fish_prompt.fish#L40).


