### PR TITLE
I tiny change to make omf theme doc clearer

### DIFF
--- a/docs/cli/omf.adoc
+++ b/docs/cli/omf.adoc
@@ -20,7 +20,7 @@ Provides options to list, download and remove packages, update the framework, cr
 <<remove.adoc#,**r**emove>>::        Remove a package.
 <<repositories.adoc#,**repo**sitories>>::  Manage package repositories.
 <<search.adoc#,**s**earch>>::        Search for a package or theme.
-<<theme.adoc#,**t**heme>>::         Install and list themes.
+<<theme.adoc#,**t**heme>>::         Activate and list available themes.
 <<update.adoc#,**u**pdate>>::        Update Oh My Fish.
 <<version.adoc#,**version**>>::       Display version and exit.
 

--- a/docs/cli/theme.adoc
+++ b/docs/cli/theme.adoc
@@ -1,8 +1,8 @@
-Install and list themes.
+Activate and list available themes.
 
 == USAGE
-  omf theme         List available themes to install
-  omf theme <name>  Install theme by name
+  omf theme         List available and installed themes
+  omf theme <name>  Activate theme by name
 
 == EXAMPLES
   omf theme

--- a/pkg/omf/completions/omf.fish
+++ b/pkg/omf/completions/omf.fish
@@ -45,6 +45,6 @@ complete -c omf -f -n "__fish_seen_subcommand_from repo repositories; and __omf_
 complete -c omf -f -n "__fish_seen_subcommand_from repo repositories; and __omf_assert_args_count 1" -a list -d "List installed repositories"
 complete -c omf -f -n "__fish_seen_subcommand_from repo repositories; and __omf_assert_args_count 1" -a remove -d "Remove a package repository"
 complete -c omf -f -a search   -n "__fish_use_subcommand" -d "Search for a plugin or theme"
-complete -c omf -f -a theme    -n "__fish_use_subcommand" -d "Install and list themes"
+complete -c omf -f -a theme    -n "__fish_use_subcommand" -d "Activate and list available themes"
 complete -c omf -f -a update   -n "__fish_use_subcommand" -d "Update Oh My Fish"
 complete -c omf -f -a version  -n "__fish_use_subcommand" -d "Display version"

--- a/pkg/omf/spec/basic_spec.fish
+++ b/pkg/omf/spec/basic_spec.fish
@@ -18,7 +18,7 @@ function describe_basic_tests
     echo $output | grep -Eq "remove.+Remove a package"
     echo $output | grep -Eq "repositories.+Manage package repositories"
     echo $output | grep -Eq "search.+Search for a package or theme"
-    echo $output | grep -Eq "theme.+Install and list themes"
+    echo $output | grep -Eq "theme.+Activate and list available themes"
     echo $output | grep -Eq "update.+Update Oh My Fish"
     echo $output | grep -Eq "version.+Display version and exit"
     assert 0 = $status


### PR DESCRIPTION
# Description

As _omf theme <name>_ won't install a theme per se, changing "install" to "activate" seems clearer. So _omf theme_ will list installed and available themes, activate an installed one, but won't install one.

Fixes # (issue)

**Environment report**

<!--
Run the command `omf doctor` and paste the output here. Example:
> omf doctor
Oh My Fish version:   7
OS type:              Linux
Fish version:         fish, versão 3.1.2
Git version:          git version 2.29.2
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.
-->

```
Oh My Fish version:   7
OS type:              Linux
Fish version:         fish, version 3.1.0
Git version:          git version 2.26.0
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.
```

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing tests pass locally with my changes <!--
