### PR TITLE
Do not set default branch during package installation

### DIFF
--- a/pkg/omf/functions/packages/omf.packages.install.fish
+++ b/pkg/omf/functions/packages/omf.packages.install.fish
@@ -16,12 +16,10 @@ function omf.packages.install -a name_or_url
     set name $name_or_url
     set url $props[2]
     set branch $props[3]
-    if test -z "$branch"
-      set branch "master"
-    end
   else
     set name (omf.packages.name $name_or_url)
     set url $name_or_url
+    set branch ""
   end
 
   if contains -- $name (omf.packages.list)

--- a/pkg/omf/functions/repo/omf.repo.clone.fish
+++ b/pkg/omf/functions/repo/omf.repo.clone.fish
@@ -1,3 +1,7 @@
 function omf.repo.clone -a url branch path
-  command git clone --quiet $url -b $branch $path
+  if test -z "$branch"
+    command git clone --quiet $url $path
+  else
+    command git clone --quiet $url -b $branch $path
+  end
 end


### PR DESCRIPTION
# Description

This allows `omf.repo.clone` to clone from a repository's default branch if no branch is specified. This fixes package installation from a URL, which previously would not work because no branch was specified.

Fixes # (issue)

**Environment report**

```
Oh My Fish version:   7-31-gf4e61aa
OS type:              Linux
Fish version:         fish, version 3.1.2
Git version:          git version 2.25.1
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.
```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes
