### PR TITLE
Improve detection of theme packages during installation

### DIFF
--- a/pkg/omf/functions/packages/omf.packages.install.fish
+++ b/pkg/omf/functions/packages/omf.packages.install.fish
@@ -41,7 +41,7 @@ function omf.packages.install -a name_or_url
 
   # If we don't know the package type yet, check if the package is a theme.
   if not set -q package_type
-    test -f $install_dir/fish_prompt.fish
+    test -f $install_dir/fish_prompt.fish -o -f $install_dir/functions/fish_prompt.fish
       and set package_type theme
       or set package_type plugin
   end


### PR DESCRIPTION
# Description

This makes the installer more flexible in detecting if a package is a theme when it is not specified from the package repository by looking in the top level directory and the `functions` directory for the `fish_prompt.fish` file.

**Environment report**

```
Oh My Fish version:   7-31-g251a792
OS type:              Linux
Fish version:         fish, version 3.1.2
Git version:          git version 2.25.1
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.
```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes