### PR TITLE
Improve nonstandard uninstall events for backwards compatability

### DIFF
--- a/docs/en-US/Packages.md
+++ b/docs/en-US/Packages.md
@@ -120,6 +120,7 @@ Inside this hook, you can access two package-related variables:
 Packages can use this hook to clean up custom resources, etc.
 
 > Note: for backwards-compatibility, uninstall hooks will also be run if they are located at `uninstall.fish` in the package root.
+> Hooks may also be triggered by listening for the event `{$package}_uninstall` or `uninstall_$package`.
 
 # Make it public
 

--- a/pkg/omf/functions/packages/omf.packages.remove.fish
+++ b/pkg/omf/functions/packages/omf.packages.remove.fish
@@ -17,8 +17,11 @@ function omf.packages.remove -a pkg
 
     # Run uninstall hook first.
     omf.packages.run_hook $path uninstall
-    source $path/uninstall.fish 2> /dev/null;
-      and emit uninstall_$pkg
+    if test -f $path/uninstall.fish
+      source $path/uninstall.fish 2> /dev/null
+    end
+    emit uninstall_$pkg
+    emit {$pkg}_uninstall
 
     if command rm -rf $path
       omf.bundle.remove "package" $pkg


### PR DESCRIPTION
# Description

This changes the `remove` script to check if an `uninstall.fish` script exists before running it. It also fires `{$pkg}_uninstall` and `uninstall_$pkg` events whether or not the file exists. This improves support for nonstandard uninstall hooks.

**Environment report**

```
Oh My Fish version:   7-31-ga579039
OS type:              Linux
Fish version:         fish, version 3.1.2
Git version:          git version 2.25.1
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.
```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes
