### PR TITLE
Installation with user/repo syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,12 @@ Update Oh My Fish, all package repositories, and all installed packages.
 - For selective package update, list only the names of packages you wish to
   update. You may still include "omf" in the list to update the core as well.
 
-#### `omf install` _`[<name>|<url>]`_
+#### `omf install` _`[<name>|<url>|<user/repo>]`_
 
 Install one _or more_ packages.
 
 - You can install packages directly by URL via `omf install URL`
+- You can install packages from a GitHub repository via `omf install user/repo`
 - When called without arguments, install missing packages from [bundle](#dotfiles).
 
 #### `omf repositories` _`[list|add|remove]`_
@@ -107,7 +108,7 @@ Apply a theme. To list available themes, type `omf theme`. You can also [preview
 
 #### `omf remove` _`<name>`_
 
-Remove a theme or package.
+Remove a theme or package. If a package was installed via `user/repo`, use `repo` for `name`.
 
 > Packages can use uninstall hooks, so custom cleanup of resources can be done when uninstalling it. See [Uninstall](/docs/en-US/Packages.md#uninstall) for more information.
 

--- a/pkg/omf/functions/packages/omf.packages.install.fish
+++ b/pkg/omf/functions/packages/omf.packages.install.fish
@@ -16,12 +16,10 @@ function omf.packages.install -a name_or_url
     set name $name_or_url
     set url $props[2]
     set branch $props[3]
-    if test -z "$branch"
-      set branch "master"
-    end
   else
     set name (omf.packages.name $name_or_url)
     set url $name_or_url
+    set branch ""
   end
 
   if contains -- $name (omf.packages.list)

--- a/pkg/omf/functions/packages/omf.packages.install.fish
+++ b/pkg/omf/functions/packages/omf.packages.install.fish
@@ -18,8 +18,12 @@ function omf.packages.install -a name_or_url
     set branch $props[3]
   else
     set name (omf.packages.name $name_or_url)
-    set url $name_or_url
     set branch ""
+    if string match -qi -r "^[a-z\d-]+/[a-z\d\-\._]+\$" $name_or_url
+      set url "https://github.com/$name_or_url"
+    else
+      set url $name_or_url
+    end
   end
 
   if contains -- $name (omf.packages.list)

--- a/pkg/omf/functions/repo/omf.repo.clone.fish
+++ b/pkg/omf/functions/repo/omf.repo.clone.fish
@@ -1,3 +1,7 @@
 function omf.repo.clone -a url branch path
-  command git clone --quiet $url -b $branch $path
+  if test -z "$branch"
+    command git clone --quiet $url $path
+  else
+    command git clone --quiet $url -b $branch $path
+  end
 end


### PR DESCRIPTION
# Description

Allows installation from GitHub repositories with `user/repo` syntax. Shorthand for URL syntax, more or less, with GitHub as the forge.

Fixes #818 

**Environment report**

```
Oh My Fish version:   7-35-g332ca07
OS type:              Linux
Fish version:         fish, version 3.1.2
Git version:          git version 2.25.1
Git core.autocrlf:    no
Checking for a sane environment...
```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes
