### PR TITLE
Solving the problem of failing to switch themes  (#826)

### DIFF
--- a/pkg/omf/functions/themes/omf.theme.set.fish
+++ b/pkg/omf/functions/themes/omf.theme.set.fish
@@ -26,7 +26,7 @@ function omf.theme.set -a target_theme
   autoload $theme_path
 
   # Find target theme's fish_prompt and link to user function path
-  for path in {$OMF_CONFIG,$OMF_PATH}/themes/$target_theme/$prompt_filename
+  for path in {$OMF_CONFIG,$OMF_PATH}/themes/$target_theme/{,functions/}$prompt_filename
     if test -e $path
       ln -sf $path $user_functions_path/$prompt_filename; and break
     end

--- a/pkg/omf/functions/util/omf.check.fish_prompt.fish
+++ b/pkg/omf/functions/util/omf.check.fish_prompt.fish
@@ -6,5 +6,5 @@ function omf.check.fish_prompt
   set -l fish_prompt (readlink "$user_functions_path/$prompt_file" 2> /dev/null)
 
   not test -e "$fish_prompt"; and return 0
-  contains -- "$fish_prompt" {$OMF_CONFIG,$OMF_PATH}/themes/$theme/$prompt_file
+  contains -- "$fish_prompt" {$OMF_CONFIG,$OMF_PATH}/themes/$theme/{,functions/}$prompt_file
 end


### PR DESCRIPTION
# Description
Failed to swith theme

when theme-zish and theme-agnoster are installed , I failed to switch from zish to agnoster and vice versa. I executed omf doctor and found the following information：

```
Warning: fish_prompt.fish is overridden.
  fish_config command persists the prompt to ~/.config/fish/functions/fish_prompt.fish
  That file takes precedence over Oh My Fish's themes. Remove the file to fix it:
  rm ~/.config/fish/functions/fish_prompt.fish
````

Fixes #826 

**Environment report**

<!--
Run the command `omf doctor` and paste the output here. Example:
-->

```
OS type:              Linux
Fish version:         fish, version 3.2.0
Git version:          git version 2.30.1
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.
```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes <!--
remove next checkbox if you didn't change the install script -->
- [ ] I have updated the SHA256 checksum for the install script
