### PR TITLE
Require bundle package after install

### DIFF
--- a/pkg/omf/functions/bundle/omf.bundle.install.fish
+++ b/pkg/omf/functions/bundle/omf.bundle.install.fish
@@ -22,8 +22,11 @@ function omf.bundle.install
         omf.packages.install $name_or_url;
           and begin
             test $type = package
-              and require $name
-              or echo "Failed to require package: $name"
+              and begin
+                require $name
+                  or echo "Failed to Require $package"
+              end
+              or true
           end
           or set error
       end

--- a/pkg/omf/functions/bundle/omf.bundle.install.fish
+++ b/pkg/omf/functions/bundle/omf.bundle.install.fish
@@ -20,6 +20,7 @@ function omf.bundle.install
 
       if not contains $name $packages
         omf.packages.install $name_or_url;
+          and require $name_or_url
           or set error
       end
     end

--- a/pkg/omf/functions/bundle/omf.bundle.install.fish
+++ b/pkg/omf/functions/bundle/omf.bundle.install.fish
@@ -20,8 +20,11 @@ function omf.bundle.install
 
       if not contains $name $packages
         omf.packages.install $name_or_url;
-          and require $name_or_url
-          or set error
+        and begin 
+          test $type = package
+            and require $name
+        end
+        or set error
       end
     end
 

--- a/pkg/omf/functions/bundle/omf.bundle.install.fish
+++ b/pkg/omf/functions/bundle/omf.bundle.install.fish
@@ -24,7 +24,7 @@ function omf.bundle.install
             test $type = package
               and begin
                 require $name
-                  or echo "Failed to Require $package"
+                  or echo "Failed to require package: $name"
               end
               or true
           end

--- a/pkg/omf/functions/bundle/omf.bundle.install.fish
+++ b/pkg/omf/functions/bundle/omf.bundle.install.fish
@@ -17,7 +17,6 @@ function omf.bundle.install
       test -n "$name_or_url"; or continue
 
       set name (omf.packages.name $name_or_url)
-      
       if not contains $name $packages
         omf.packages.install $name_or_url;
           and begin

--- a/pkg/omf/functions/bundle/omf.bundle.install.fish
+++ b/pkg/omf/functions/bundle/omf.bundle.install.fish
@@ -17,14 +17,19 @@ function omf.bundle.install
       test -n "$name_or_url"; or continue
 
       set name (omf.packages.name $name_or_url)
-
+      
       if not contains $name $packages
         omf.packages.install $name_or_url;
-        and begin 
-          test $type = package
-            and require $name
-        end
-        or set error
+        
+          # require if not a theme
+          and begin 
+            test $type = package; and begin
+              require $name
+                or echo "Failed to require $name"
+            end
+            or echo "Skipped require $name"
+          end
+          or set error
       end
     end
 

--- a/pkg/omf/functions/bundle/omf.bundle.install.fish
+++ b/pkg/omf/functions/bundle/omf.bundle.install.fish
@@ -20,14 +20,10 @@ function omf.bundle.install
       
       if not contains $name $packages
         omf.packages.install $name_or_url;
-        
-          # require if not a theme
-          and begin 
-            test $type = package; and begin
-              require $name
-                or echo "Failed to require $name"
-            end
-            or echo "Skipped require $name"
+          and begin
+            test $type = package
+              and require $name
+              or echo "Failed to require package: $name"
           end
           or set error
       end


### PR DESCRIPTION
# Description

After a package dependency was installed from the bundle file, the dependency package was not available for use by the plugin to be installed,. Thus, causing issues with plugins which relied on dependency packages during installation. Added require to packages installed from bundle file as dependencies. 

Fixes Related Issue: https://github.com/oh-my-fish/plugin-weather/issues/38

**Environment report**

```
Oh My Fish version:   7-35-g3c0c810
OS type:              Linux
Fish version:         fish, version 3.3.1
Git version:          git version 2.32.0
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.
```

# Checklist:

- [*] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] I have made corresponding changes to the documentation
- [*] New and existing tests pass locally with my changes