### PR TITLE
workflow: Update virtual environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-16.04
           - ubuntu-18.04
-          - ubuntu-20.04
           - ubuntu-latest
         fish:
           - stock
@@ -21,9 +19,9 @@ jobs:
           - os: ubuntu-latest
             fish: 2
         include:
-          - os: macos-10.15
-            fish: brew
           - os: macos-latest
+            fish: brew
+          - os: macos-11
             fish: brew
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
`ubuntu-16.04` has been removed from [virtual-environments](/actions/virtual-environments) while `macos-11` has been added.