### PR TITLE
omf.packages.name: Fix regex by escaping a dot

### DIFF
--- a/pkg/omf/functions/packages/omf.packages.name.fish
+++ b/pkg/omf/functions/packages/omf.packages.name.fish
@@ -1,3 +1,3 @@
 function omf.packages.name -a name_or_url
-  command basename $name_or_url | sed -E 's/^(omf-)?((plugin|pkg|theme)-)?//;s/.git$//'
+  command basename $name_or_url | sed -E 's/^(omf-)?((plugin|pkg|theme)-)?//;s/\\.git$//'
 end

--- a/pkg/omf/spec/omf_packages_spec.fish
+++ b/pkg/omf/spec/omf_packages_spec.fish
@@ -1,0 +1,77 @@
+function describe_omf_packages_tests
+  function before_all
+    set -gx CI WORKAROUND
+  end
+
+  function it_can_extract_name_from_name
+    set -l output (omf.packages.name foo)
+    assert 0 = $status
+    assert "foo" = "$output"
+  end
+
+  function it_can_extract_name_of_a_plugin_package
+    set -l output (omf.packages.name plugin-foo)
+    assert 0 = $status
+    assert "foo" = "$output"
+  end
+
+  function it_can_extract_name_of_a_theme_package
+    set -l output (omf.packages.name theme-foo)
+    assert 0 = $status
+    assert "foo" = "$output"
+  end
+
+  function it_can_extract_name_from_name_ended_in_dot_git
+    set -l output (omf.packages.name foo.git)
+    assert 0 = $status
+    assert "foo" = "$output"
+  end
+
+  function it_can_extract_name_from_name_with_dot
+    set -l output (omf.packages.name foo.bar)
+    assert 0 = $status
+    assert "foo.bar" = "$output"
+  end
+
+  function it_can_extract_name_from_name_ended_in_git
+    set -l output (omf.packages.name foobargit)
+    assert 0 = $status
+    assert "foobargit" = "$output"
+  end
+
+  function it_can_extract_name_from_url
+    set -l output (omf.packages.name http://github.com/user/foo)
+    assert 0 = $status
+    assert "foo" = "$output"
+  end
+
+  function it_can_extract_name_from_url_of_a_plugin_package
+    set -l output (omf.packages.name http://github.com/user/plugin-foo)
+    assert 0 = $status
+    assert "foo" = "$output"
+  end
+
+  function it_can_extract_name_from_url_of_a_theme_package
+    set -l output (omf.packages.name http://github.com/user/theme-foo)
+    assert 0 = $status
+    assert "foo" = "$output"
+  end
+
+  function it_can_extract_name_from_url_ended_in_dot_git
+    set -l output (omf.packages.name http://github.com/user/foo.git)
+    assert 0 = $status
+    assert "foo" = "$output"
+  end
+
+  function it_can_extract_name_from_url_with_dot
+    set -l output (omf.packages.name http://github.com/user/foo.bar)
+    assert 0 = $status
+    assert "foo.bar" = "$output"
+  end
+
+  function it_can_extract_name_from_url_ended_in_git
+    set -l output (omf.packages.name http://github.com/user/foobargit)
+    assert 0 = $status
+    assert "foobargit" = "$output"
+  end
+end


### PR DESCRIPTION
# Description

With this change, `omf.packages.name` escapes a dot that was matching any character and extracting partial names from names or URLs.

Fixes #901

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] New and existing tests pass locally with my changes
- [ ] ~~I have updated the SHA256 checksum for the install script~~
