### PR TITLE
Support installing repo from URL with non-master branch

### DIFF
--- a/pkg/omf/functions/repo/omf.repo.pull.fish
+++ b/pkg/omf/functions/repo/omf.repo.pull.fish
@@ -1,10 +1,10 @@
 function omf.repo.pull -a repo_dir branch
-  if test -z "$branch"
-    set branch "master"
-  end
-
   function __omf.repo.git -V repo_dir
     command git -C "$repo_dir" $argv
+  end
+
+  if test -z "$branch"
+    set branch (__omf.repo.git symbolic-ref -q --short HEAD)
   end
 
   set -l remote origin


### PR DESCRIPTION
Somewhat related to #905 and #685, but by use-case is not a package in packages-main repo, but a [GitLab repo](https://gitlab.com/txlab/fish-functions), for which install currently works fine, but `omf update` results in this:
(on `omf channel dev`)
```
Oh My Fish is up to date.
You are now using Oh My Fish version 7-44-gd428b72.
Updating https://github.com/oh-my-fish/packages-main master... Done!
fatal: couldn't find remote ref refs/heads/master
Could not update fish-functions.
bobthefish is already up-to-date.
default is already up-to-date.
```

While debugging I found `set branch "master"` in `pkg/omf/functions/repo/omf.repo.pull.fish` and changed it to use current branch as fallback/default an old convention

I tried thinking of all the edge-cases you're covering, but not sure if I understood correctly.

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes
