### PR TITLE
Fix #924: Checksum isn't up to date in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ fish install --path=~/.local/share/omf --config=~/.config/omf
 You can verify the integrity of the downloaded installer by verifying the script against [this checksum](bin/install.sha256):
 
 ```
-429a76e5b5e692c921aa03456a41258b614374426f959535167222a28b676201 install
+curl -sL https://raw.githubusercontent.com/oh-my-fish/oh-my-fish/master/bin/install.sha256 | shasum -a 256 --check
 ```
 
 You can also install Oh My Fish with Git or with an offline source tarball downloaded from the [releases page][releases]:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ fish install --path=~/.local/share/omf --config=~/.config/omf
 You can verify the integrity of the downloaded installer by verifying the script against [this checksum](bin/install.sha256):
 
 ```
-bb1f4025934600ea6feef2ec11660e17e2b6449c5a23c033860aed712ad328c9 install
+429a76e5b5e692c921aa03456a41258b614374426f959535167222a28b676201 install
 ```
 
 You can also install Oh My Fish with Git or with an offline source tarball downloaded from the [releases page][releases]:


### PR DESCRIPTION
Seems like this is likely to happen again in the future -- people will remember to update the SHA256 file but not the`README.md`. Couldn't find a way to embed a file into markdown, maybe add this as another checkbox in the PR template? Or remove the hash from the README.md entirely?