### PR TITLE
chore: update CI to latest OS and Fish versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,25 +12,25 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
           - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-latest
         fish:
           - stock
-          - 2
           - 3
+          - 4
           - brew
         exclude:
           - os: ubuntu-20.04
-            fish: 2
+            fish: 4
           - os: ubuntu-latest
-            fish: 2
+            fish: 4
         include:
           - os: macos-latest
             fish: brew
-          - os: macos-11
+          - os: macos-13
             fish: brew
-          - os: macos-12
+          - os: macos-14
             fish: brew
     runs-on: ${{ matrix.os }}
     steps:

--- a/tools/ci-install-fish.sh
+++ b/tools/ci-install-fish.sh
@@ -8,8 +8,8 @@ if [[ $FISH_RELEASE = "brew" ]]; then
   brew update
   brew install fish
 else
-  if [[ $FISH_RELEASE == "2" ]]; then
-    REPO_PPA="ppa:fish-shell/release-2"
+  if [[ $FISH_RELEASE == "4" ]]; then
+    REPO_PPA="ppa:fish-shell/beta-4"
   else
     REPO_PPA="ppa:fish-shell/release-3"
   fi


### PR DESCRIPTION
# Description

Well, it happens that CI is currently completely broken. Linux and macOS versions have been retired from GH actions. This updates CI to run on Fish 3.0 and 4.0, as well as on least recent supported and most recent supported Linux and macOS operating systems.

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes <!--
remove next checkbox if you didn't change the install script -->
- [ ] I have updated the SHA256 checksum for the install script
