### PR TITLE
fix conf.d $path variable

### DIFF
--- a/lib/require.fish
+++ b/lib/require.fish
@@ -79,6 +79,8 @@ function require
   end
 
   for conf in $conf_path
+    echo $conf | read --delimiter '/' -la components
+    set path (printf '/%s' $components[1..-3])
     source $conf
   end
 


### PR DESCRIPTION
# Description

The $path variable when evaluating `conf.d` scripts was being set to the last package `init.fish` path. This fixes it so it points to the root of the package.

**Environment report**

<!--
Run the command `omf doctor` and paste the output here. Example:
-->

```
Oh My Fish version:   7-62-gbae61e4
OS type:              Darwin
Fish version:         fish, version 4.0.2
Git version:          git version 2.39.5 (Apple Git-154)
Git core.autocrlf:    no
```

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/oh-my-fish/oh-my-fish/blob/master/CONTRIBUTING.md#code-style) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes <!--
remove next checkbox if you didn't change the install script -->
- [ ] I have updated the SHA256 checksum for the install script
