### PR TITLE
test: make the test suite real (assertions that assert, isolated harness)

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -8,12 +8,6 @@ runs:
       if: runner.os == 'macOS'
       run: brew update && brew install fish
 
-    - name: Install Oh My Fish!
+    - name: Run tests
       shell: bash
-      run: fish bin/install --verbose --offline --noninteractive --yes
-
-    - name: Run tests on latest fish
-      shell: bash
-      run: |
-        tests/run.fish
-        fish -c 'fish-spec pkg/{fish-spec,omf}/spec/*_spec.fish'
+      run: tests/run.fish

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ like so: `fish-spec tests/test_*.fish other-tests/foo.fish`
 For syntax and available assertions see the tests for the fish-spec package in
 [pkg/fish-spec/spec/](https://github.com/oh-my-fish/oh-my-fish/tree/master/pkg/fish-spec/spec).
 
+To run Oh My Fish's own test suite, use `tests/run.fish`. It installs Oh My Fish into a temporary sandbox
+(a throwaway `HOME`), so your real configuration is never touched, then runs the smoke tests and every
+`spec/*_spec.fish` under `pkg/`. Pass spec files as arguments to run a subset.
+
 ## Creating Packages
 
 Oh My Fish uses an advanced and well defined plugin architecture to ease plugin development, including init/uninstall hooks, function and completion autoloading. [See the packages documentation](docs/en-US/Packages.md) for more details.

--- a/pkg/fish-spec/framework/assertions.fish
+++ b/pkg/fish-spec/framework/assertions.fish
@@ -1,180 +1,168 @@
-function __fish_spec_assert_generic -a first second success_template failure_template test_command
+# Record the outcome of an assertion.
+#
+# Every assert_* helper runs its check directly and passes the resulting
+# $status here together with a success and a failure message. No `eval` is
+# involved, so assertion arguments containing quotes, parentheses or regex
+# metacharacters are never re-parsed as fish code.
+function __fish_spec_assert_result -a result success_message failure_message
   set __fish_spec_total_assertions_in_file (math $__fish_spec_total_assertions_in_file + 1)
 
-  if eval not "$test_command"
+  if test "$result" -ne 0
     set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file + 1)
     set __fish_spec_last_assertion_failed yes
-    eval __fish_spec.color.echo.failure "$failure_template"
+    __fish_spec.color.echo.failure "$failure_message"
     return 1
   end
   if test "$FISH_SPEC_VERBOSE" = 1
-    eval __fish_spec.color.echo.success "$success_template"
+    __fish_spec.color.echo.success "$success_message"
   end
+  return 0
 end
 
+# assert <test arguments...>
+# Passes each argument to `test` separately, e.g. `assert 1 = 2`.
 function assert
-  set -l first "$argv"
-  __fish_spec_assert_generic \
-    $first unused \
-    'Assertion \"test $first\" passed!' \
-    'Assertion failed: \"test $first\" evaluated to false.' \
-    "test '$argv'"
-    return $status
+  test $argv
+  __fish_spec_assert_result $status \
+    "Assertion \"test $argv\" passed!" \
+    "Assertion failed: \"test $argv\" evaluated to false."
 end
 
-function assert_equal -a first second
-  __fish_spec_assert_generic \
-    $first $second \
-    'Assertion \"$first\" == \"$second\" passed!' \
-    'Assertion failed: Expected \"$first\", but got \"$second\".' \
-    'test "$first" = "$second"'
+function assert_equal -a expected actual
+  test "$expected" = "$actual"
+  __fish_spec_assert_result $status \
+    "Assertion \"$expected\" == \"$actual\" passed!" \
+    "Assertion failed: Expected \"$expected\", but got \"$actual\"."
 end
 
-function assert_not_equal -a first second
-  __fish_spec_assert_generic \
-    $first $second \
-    'Assertion \"$first\" != \"$second\" passed!' \
-    'Assertion failed: Expected \"$second\" to be different from \"$expecte\".' \
-    'test "$first" != "$second"'
+function assert_not_equal -a expected actual
+  test "$expected" != "$actual"
+  __fish_spec_assert_result $status \
+    "Assertion \"$expected\" != \"$actual\" passed!" \
+    "Assertion failed: Expected \"$actual\" to be different from \"$expected\"."
 end
 
+# assert_exit_code <expected>
+# Checks the exit status of the command that ran immediately before it.
 function assert_exit_code -a expected_status
-  __fish_spec_assert_generic \
-    $expected_status $status \
-    'Assertion exit code $second == $first passed!' \
-    'Assertion failed: Expected exit code $first, but got $second.' \
-    'test "$first" -eq "$second"'
+  set -l actual_status $status
+  test "$expected_status" -eq "$actual_status"
+  __fish_spec_assert_result $status \
+    "Assertion exit code $actual_status == $expected_status passed!" \
+    "Assertion failed: Expected exit code $expected_status, but got $actual_status."
 end
 
 function assert_ok
-  assert_exit_code 0
+  set -l actual_status $status
+  test "$actual_status" -eq 0
+  __fish_spec_assert_result $status \
+    "Assertion exit code $actual_status == 0 passed!" \
+    "Assertion failed: Expected exit code 0, but got $actual_status."
 end
 
 function assert_true -a condition
-  __fish_spec_assert_generic \
-    $condition 0 \
-    'Assertion \"$first\" is true passed!' \
-    'Assertion failed: Expected true, but got \"$first\".' \
-    'test $first'
+  test -n "$condition" -a "$condition" != 0 -a "$condition" != false
+  __fish_spec_assert_result $status \
+    "Assertion \"$condition\" is true passed!" \
+    "Assertion failed: Expected true, but got \"$condition\"."
 end
 
 function assert_false -a condition
-  __fish_spec_assert_generic \
-    $condition 0 \
-    'Assertion \"$first\" is false passed!' \
-    'Assertion failed: Expected false, but got \"$first\".' \
-    'test ! $first'
+  test -z "$condition" -o "$condition" = 0 -o "$condition" = false
+  __fish_spec_assert_result $status \
+    "Assertion \"$condition\" is false passed!" \
+    "Assertion failed: Expected false, but got \"$condition\"."
 end
 
 function assert_match -a pattern string
-  __fish_spec_assert_generic \
-    $pattern $string \
-    'Assertion string \"$string\" matches pattern \"$pattern\" passed!' \
-    'Assertion failed: string \"$second\" does not match pattern \"$first\".' \
-    'string match -qr $first $second'
+  string match -qr -- "$pattern" "$string"
+  __fish_spec_assert_result $status \
+    "Assertion string \"$string\" matches pattern \"$pattern\" passed!" \
+    "Assertion failed: string \"$string\" does not match pattern \"$pattern\"."
 end
 
-
-function assert_match -a pattern string
-  __fish_spec_assert_generic \
-    $pattern $string \
-    'Assertion string \"$string\" does not match pattern \"$pattern\" passed!' \
-    'Assertion failed: string \"$second\" does not match pattern \"$first\".' \
-    'not string match -qr $first $second'
+function assert_not_match -a pattern string
+  not string match -qr -- "$pattern" "$string"
+  __fish_spec_assert_result $status \
+    "Assertion string \"$string\" does not match pattern \"$pattern\" passed!" \
+    "Assertion failed: string \"$string\" matches pattern \"$pattern\"."
 end
 
 function assert_file_exists -a file
-  __fish_spec_assert_generic \
-    $file unused \
-    'Assertion file \"$first\" exists passed!' \
-    'Assertion failed: File \"$first\" does not exist.' \
-    'test -f $first'
+  test -f "$file"
+  __fish_spec_assert_result $status \
+    "Assertion file \"$file\" exists passed!" \
+    "Assertion failed: File \"$file\" does not exist."
 end
 
 function assert_file_does_not_exist -a file
-  __fish_spec_assert_generic \
-    $file unused \
-    'Assertion file \"$first\" does not exist passed!' \
-    'Assertion failed: File \"$first\" exists.' \
-    'not test -f $first'
+  not test -f "$file"
+  __fish_spec_assert_result $status \
+    "Assertion file \"$file\" does not exist passed!" \
+    "Assertion failed: File \"$file\" exists."
 end
 
 function assert_directory_exists -a dir
-  __fish_spec_assert_generic \
-    $dir unused \
-    'Assertion directory \"$first\" exists passed!' \
-    'Assertion failed: Directory \"$first\" does not exist.' \
-    'test -d $dir'
+  test -d "$dir"
+  __fish_spec_assert_result $status \
+    "Assertion directory \"$dir\" exists passed!" \
+    "Assertion failed: Directory \"$dir\" does not exist."
 end
 
-function assert_directory_does_not_exist -a file
-  __fish_spec_assert_generic \
-    $file unused \
-    'Assertion directory \"$first\" does not exist passed!' \
-    'Assertion failed: Directory \"$first\" exists.' \
-    'not test -d $first'
+function assert_directory_does_not_exist -a dir
+  not test -d "$dir"
+  __fish_spec_assert_result $status \
+    "Assertion directory \"$dir\" does not exist passed!" \
+    "Assertion failed: Directory \"$dir\" exists."
 end
 
 function assert_file_empty -a file
-  __fish_spec_assert_generic \
-    $file unused \
-    'Assertion file $first is empty passed!' \
-    'Assertion failed: File \"$first\" is not empty.' \
-    'not test -s $file'
+  not test -s "$file"
+  __fish_spec_assert_result $status \
+    "Assertion file \"$file\" is empty passed!" \
+    "Assertion failed: File \"$file\" is not empty."
 end
 
 function assert_file_contains -a file content
-  __fish_spec_assert_generic \
-    $file $content \
-    'Assertion $first contains \"$second\" passed!' \
-    'Assertion failed: File \"$first\" does not contain \"$second\".' \
-    'grep -q "$second" $first'
+  grep -qF -- "$content" "$file"
+  __fish_spec_assert_result $status \
+    "Assertion $file contains \"$content\" passed!" \
+    "Assertion failed: File \"$file\" does not contain \"$content\"."
 end
 
 function assert_file_contains_regex -a file pattern
-  __fish_spec_assert_generic \
-    $file $pattern \
-    'Assertion $first content matches regex \"$second\" passed!' \
-    'Assertion failed: File \"$first\" does not contain a string matching the pattern \"$second\".' \
-    'grep -qE "$second" $first'
+  grep -qE -- "$pattern" "$file"
+  __fish_spec_assert_result $status \
+    "Assertion $file content matches regex \"$pattern\" passed!" \
+    "Assertion failed: File \"$file\" does not contain a string matching the pattern \"$pattern\"."
 end
 
 function assert_not_file_contains -a file content
-  __fish_spec_assert_generic \
-    $file $content \
-    'Assertion $first does not contain \"$content\" passed!' \
-    'Assertion failed: File \"$first\" contains \"$second\".' \
-    'not grep -q "$second" $first'
+  not grep -qF -- "$content" "$file"
+  __fish_spec_assert_result $status \
+    "Assertion $file does not contain \"$content\" passed!" \
+    "Assertion failed: File \"$file\" contains \"$content\"."
 end
 
 function assert_not_file_contains_regex -a file pattern
-  __fish_spec_assert_generic \
-    $file $pattern \
-    'Assertion $first content does not match regex \"$second\" passed!' \
-    'Assertion failed: File \"$first\" contains a string matching the pattern \"$second\".' \
-    'not grep -qE "$second" $first'
+  not grep -qE -- "$pattern" "$file"
+  __fish_spec_assert_result $status \
+    "Assertion $file content does not match regex \"$pattern\" passed!" \
+    "Assertion failed: File \"$file\" contains a string matching the pattern \"$pattern\"."
 end
 
 function assert_in_array -a value
-  set -g __fish_spec_assertion_array $argv[2..-1]
-  __fish_spec_assert_generic \
-    $value "$__fish_spec_assertion_array" \
-    'Assertion \"$first\" in [$second] passed!' \
-    'Assertion failed: Value \"$first\" is not in the array [$second].' \
-    'contains -- $first $__fish_spec_assertion_array'
-  set result $status
-  set -e __fish_spec_assertion_array
-  return $result
+  set -l array $argv[2..-1]
+  contains -- "$value" $array
+  __fish_spec_assert_result $status \
+    "Assertion \"$value\" in [$array] passed!" \
+    "Assertion failed: Value \"$value\" is not in the array [$array]."
 end
 
 function assert_not_in_array -a value
-  set -g __fish_spec_assertion_array $argv[2..-1]
-  __fish_spec_assert_generic \
-    $value "$__fish_spec_assertion_array" \
-    'Assertion \"$first\" not in [$second] passed!' \
-    'Assertion failed: Value \"$first\" is in the array [$second].' \
-    'not contains -- $first $__fish_spec_assertion_array'
-  set result $status
-  set -e __fish_spec_assertion_array
-  return $result
+  set -l array $argv[2..-1]
+  not contains -- "$value" $array
+  __fish_spec_assert_result $status \
+    "Assertion \"$value\" not in [$array] passed!" \
+    "Assertion failed: Value \"$value\" is in the array [$array]."
 end

--- a/pkg/fish-spec/framework/assertions.fish
+++ b/pkg/fish-spec/framework/assertions.fish
@@ -74,14 +74,19 @@ function assert_false -a condition
     "Assertion failed: Expected false, but got \"$condition\"."
 end
 
-function assert_match -a pattern string
+# assert_match <pattern> <string>...
+# Everything after the pattern is joined with spaces, so an unquoted
+# multi-line command substitution is matched as a whole.
+function assert_match -a pattern
+  set -l string "$argv[2..-1]"
   string match -qr -- "$pattern" "$string"
   __fish_spec_assert_result $status \
     "Assertion string \"$string\" matches pattern \"$pattern\" passed!" \
     "Assertion failed: string \"$string\" does not match pattern \"$pattern\"."
 end
 
-function assert_not_match -a pattern string
+function assert_not_match -a pattern
+  set -l string "$argv[2..-1]"
   not string match -qr -- "$pattern" "$string"
   __fish_spec_assert_result $status \
     "Assertion string \"$string\" does not match pattern \"$pattern\" passed!" \

--- a/pkg/fish-spec/functions/fish-spec.fish
+++ b/pkg/fish-spec/functions/fish-spec.fish
@@ -15,7 +15,17 @@ function fish-spec
     set test_files $argv
   end
 
+  if not set -q test_files[1]
+    __fish_spec.color.echo.failure "fish-spec: no spec files found"
+    return 1
+  end
+
   for test_file in $test_files
+    if not test -f $test_file
+      __fish_spec.color.echo.failure "fish-spec: no such spec file: $test_file"
+      set __fish_spec_failed_assertions (math $__fish_spec_failed_assertions + 1)
+      continue
+    end
     __fish_spec_run_tests_in_file $test_file
   end
 
@@ -34,7 +44,12 @@ function __fish_spec_run_tests_in_file -a test_file
   set -g __fish_spec_last_assertion_failed no
 
   __fish_spec.color.echo.info "Running tests in $test_file..."
+  # fish < 4 returns non-zero when sourcing an empty file; that is not an error.
   source $test_file
+  if test $status -ne 0 -a -s $test_file
+    __fish_spec.color.echo.failure "fish-spec: could not load $test_file"
+    set __fish_spec_failed_assertions_in_file 1
+  end
 
   for suite in (functions | string match -r '^describe_.*')
     __fish_spec_run_tests_in_suite $suite

--- a/pkg/fish-spec/functions/fish-spec.fish
+++ b/pkg/fish-spec/functions/fish-spec.fish
@@ -29,6 +29,11 @@ function fish-spec
     __fish_spec_run_tests_in_file $test_file
   end
 
+  if test $__fish_spec_total_assertions -eq 0
+    __fish_spec.color.echo.failure "fish-spec: no assertions ran"
+    set __fish_spec_failed_assertions 1
+  end
+
   # Global summary
   echo
   __fish_spec.color.echo.autocolor $__fish_spec_total_assertions $__fish_spec_failed_assertions "Test complete: $__fish_spec_total_assertions assertions run, $__fish_spec_failed_assertions failed."

--- a/pkg/fish-spec/functions/fish-spec.fish
+++ b/pkg/fish-spec/functions/fish-spec.fish
@@ -42,6 +42,9 @@ function __fish_spec_run_tests_in_file -a test_file
 
   functions -e (functions | string match -r '^(describe_.*)$')
 
+  set __fish_spec_failed_assertions (math $__fish_spec_failed_assertions + $__fish_spec_failed_assertions_in_file)
+  set __fish_spec_total_assertions (math $__fish_spec_total_assertions + $__fish_spec_total_assertions_in_file)
+
   # File-level summary
   echo
   __fish_spec.color.echo.autocolor $__fish_spec_total_assertions_in_file $__fish_spec_failed_assertions_in_file "Summary for $test_file: $__fish_spec_total_assertions_in_file assertions, $__fish_spec_failed_assertions_in_file failed."
@@ -60,9 +63,6 @@ function __fish_spec_run_tests_in_suite -a suite
     __fish_spec_run_test_function $test_func
   end
 
-  set __fish_spec_failed_assertions (math $__fish_spec_failed_assertions + $__fish_spec_failed_assertions_in_file)
-  set __fish_spec_total_assertions (math $__fish_spec_total_assertions + $__fish_spec_total_assertions_in_file)
-
   if functions --query after_all
     after_all
   end
@@ -77,7 +77,7 @@ function __fish_spec_run_test_function -a test_func
 
   set -l before_each_output ""
   if functions --query before_each
-    before_each 2>1 | while read -l line; test -z "$before_each_output" && set before_each_output $line || set before_each_output $before_each_output\n$line; end
+    before_each 2>&1 | while read -l line; test -z "$before_each_output" && set before_each_output $line || set before_each_output $before_each_output\n$line; end
   end
 
   set -l test_func_output ""

--- a/pkg/fish-spec/spec/assertions_spec.fish
+++ b/pkg/fish-spec/spec/assertions_spec.fish
@@ -1,4 +1,7 @@
 function __fish_spec_undo_expected_failure
+  # Only undo when the preceding `assert_exit_code 1` succeeded, i.e. the
+  # assertion under test really did fail. Otherwise the failure is real.
+  test $status -eq 0; or return 1
   set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
   set __fish_spec_last_assertion_failed no
 end
@@ -68,6 +71,27 @@ function describe_assertions
     assert_not_match '^abc' abcdef
     assert_exit_code 1
     __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_match_joins_multiple_arguments
+    set -l lines first second third
+    assert_match 'second' $lines
+    assert_exit_code 0
+    assert_match '^first second third$' $lines
+    assert_exit_code 0
+  end
+
+  function it_does_not_undo_a_real_failure
+    set -l failed_before $__fish_spec_failed_assertions_in_file
+    assert 1 = 1
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+    assert_exit_code 1
+    # The wrongly expected failure above is genuine and must remain counted.
+    assert_equal (math $failed_before + 1) $__fish_spec_failed_assertions_in_file
+    # Undo it for real now that the bookkeeping has been verified.
+    set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
+    set __fish_spec_last_assertion_failed no
   end
 
   function it_assert_match_treats_arguments_as_data

--- a/pkg/fish-spec/spec/assertions_spec.fish
+++ b/pkg/fish-spec/spec/assertions_spec.fish
@@ -1,0 +1,141 @@
+function __fish_spec_undo_expected_failure
+  set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
+  set __fish_spec_last_assertion_failed no
+end
+
+function describe_assertions
+  function before_all
+    set -g __spec_tmp (mktemp -d)
+    echo "hello world" > $__spec_tmp/full
+    touch $__spec_tmp/empty
+  end
+
+  function after_all
+    rm -rf $__spec_tmp
+    set -e __spec_tmp
+  end
+
+  function it_assert_passes_arguments_separately
+    assert 1 = 2
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+
+    assert -n ""
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+
+    assert -z ""
+    assert_exit_code 0
+  end
+
+  function it_assert_equal_and_not_equal
+    assert_equal abc abc
+    assert_exit_code 0
+    assert_not_equal abc abd
+    assert_exit_code 0
+
+    assert_equal abc abd
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+    assert_not_equal abc abc
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_exit_code_reads_previous_status
+    false
+    assert_exit_code 1
+    true
+    assert_ok
+    sh -c 'exit 7'
+    assert_exit_code 7
+
+    false
+    assert_ok
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_match_and_not_match
+    assert_match '^abc' abcdef
+    assert_exit_code 0
+    assert_not_match '^abc' zzz
+    assert_exit_code 0
+
+    assert_match '^abc' zzz
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+    assert_not_match '^abc' abcdef
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_match_treats_arguments_as_data
+    assert_match '\(' 'a(b'
+    assert_exit_code 0
+    assert_match '-x' 'a-x'
+    assert_exit_code 0
+  end
+
+  function it_assert_file_and_directory_helpers
+    assert_file_exists $__spec_tmp/full
+    assert_exit_code 0
+    assert_file_does_not_exist $__spec_tmp/missing
+    assert_exit_code 0
+    assert_directory_exists $__spec_tmp
+    assert_exit_code 0
+    assert_directory_does_not_exist $__spec_tmp/missing
+    assert_exit_code 0
+    assert_file_empty $__spec_tmp/empty
+    assert_exit_code 0
+
+    assert_directory_exists $__spec_tmp/missing
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+    assert_file_empty $__spec_tmp/full
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+    assert_file_exists $__spec_tmp/missing
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_file_contents
+    assert_file_contains $__spec_tmp/full world
+    assert_exit_code 0
+    assert_not_file_contains $__spec_tmp/full mars
+    assert_exit_code 0
+    assert_file_contains_regex $__spec_tmp/full '^hello'
+    assert_exit_code 0
+    assert_not_file_contains_regex $__spec_tmp/full '^world'
+    assert_exit_code 0
+
+    assert_file_contains $__spec_tmp/full mars
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_arrays
+    assert_in_array b a b c
+    assert_exit_code 0
+    assert_not_in_array z a b c
+    assert_exit_code 0
+
+    assert_in_array z a b c
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_true_and_false
+    assert_true 1
+    assert_exit_code 0
+    assert_false 0
+    assert_exit_code 0
+    assert_false ""
+    assert_exit_code 0
+
+    assert_true 0
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+end

--- a/pkg/fish-spec/spec/results_spec.fish
+++ b/pkg/fish-spec/spec/results_spec.fish
@@ -1,8 +1,14 @@
+# Undo the bookkeeping of an assertion that was *expected* to fail, so a
+# deliberately failing assertion does not mark the test or the run as failed.
+function __fish_spec_undo_expected_failure
+  set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
+  set __fish_spec_last_assertion_failed no
+end
+
 function describe_results
   function it_succeeds_when_single_assertion_succeeds
     assert 1 = 1
-
-    assert 0 = $status
+    assert_exit_code 0
   end
 
   function it_succeeds_when_multiple_assertion_succeeds
@@ -11,21 +17,28 @@ function describe_results
   end
 
   function it_fails_when_single_assertion_fails
-    set previous_assertion_counter $__fish_spec_failed_assertions_in_file
+    set -l failed_before $__fish_spec_failed_assertions_in_file
     assert 1 = 2
     assert_exit_code 1
-    echo decrement failed assertion counter so tests pass as expected
-    set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
-    assert_equal $previous_assertion_counter $__fish_spec_failed_assertions_in_file
+    assert_equal (math $failed_before + 1) $__fish_spec_failed_assertions_in_file
+    assert_equal yes $__fish_spec_last_assertion_failed
+    __fish_spec_undo_expected_failure
   end
 
   function it_fails_when_one_of_the_assertions_fails
-    set previous_assertion_counter $__fish_spec_failed_assertions_in_file
+    set -l failed_before $__fish_spec_failed_assertions_in_file
     assert 1 = 2
     assert_exit_code 1
     assert 2 = 2
-    echo decrement failed assertion counter so tests pass as expected
-    set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
-    assert_equal $previous_assertion_counter $__fish_spec_failed_assertions_in_file
+    assert_exit_code 0
+    assert_equal (math $failed_before + 1) $__fish_spec_failed_assertions_in_file
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_counts_every_assertion
+    set -l total_before $__fish_spec_total_assertions_in_file
+    assert 1 = 1
+    assert_equal a a
+    assert_equal (math $total_before + 2) $__fish_spec_total_assertions_in_file
   end
 end

--- a/pkg/fish-spec/spec/results_spec.fish
+++ b/pkg/fish-spec/spec/results_spec.fish
@@ -1,6 +1,9 @@
 # Undo the bookkeeping of an assertion that was *expected* to fail, so a
 # deliberately failing assertion does not mark the test or the run as failed.
 function __fish_spec_undo_expected_failure
+  # Only undo when the preceding `assert_exit_code 1` succeeded, i.e. the
+  # assertion under test really did fail. Otherwise the failure is real.
+  test $status -eq 0; or return 1
   set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
   set __fish_spec_last_assertion_failed no
 end

--- a/pkg/omf/functions/cli/omf.cli.list.fish
+++ b/pkg/omf/functions/cli/omf.cli.list.fish
@@ -1,10 +1,10 @@
 function omf.cli.list
   switch (count $argv)
   case 0
-    echo (set_color -u)Plugins(set_color normal)
+    echo (omf::under)Plugins(omf::off)
     omf.packages.list --plugin | column
     echo
-    echo (set_color -u)Themes(set_color normal)
+    echo (omf::under)Themes(omf::off)
     omf.packages.list --theme | column
   case '*'
     omf.packages.list $argv | column

--- a/pkg/omf/functions/cli/omf.cli.reload.fish
+++ b/pkg/omf/functions/cli/omf.cli.reload.fish
@@ -9,7 +9,7 @@ function omf.cli.reload
 end
 
 function __omf.cli.reload.job_warning
-  echo (set_color -u)"Reload aborted. There are background jobs:"(set_color normal)
+  echo (omf::under)"Reload aborted. There are background jobs:"(omf::off)
   echo
   jobs
   echo

--- a/pkg/omf/functions/compat/available.fish
+++ b/pkg/omf/functions/compat/available.fish
@@ -1,7 +1,7 @@
 function available
   echo (status -t)[5] | read -la caller
   printf 'warning: function %savailable%s is deprecated and will be removed soon.\n' \
-  (set_color -u) (set_color normal)
+  (omf::under) (omf::off)
 
   contains input $caller
     or echo $caller

--- a/pkg/omf/functions/compat/refresh.fish
+++ b/pkg/omf/functions/compat/refresh.fish
@@ -1,7 +1,7 @@
 function refresh -d "(deprecated) Refresh fish session by replacing current process"
   echo (status -t)[5] | read -la caller
   printf 'warning: function %srefresh%s is deprecated and will be removed soon.\n' \
-  (set_color -u) (set_color normal)
+  (omf::under) (omf::off)
 
   contains input $caller
     or echo $caller

--- a/pkg/omf/init.fish
+++ b/pkg/omf/init.fish
@@ -3,24 +3,34 @@ set -g OMF_UNKNOWN_OPT   2
 set -g OMF_INVALID_ARG   3
 set -g OMF_UNKNOWN_ERR   4
 
+# Colour helpers. They are used as `echo (omf::em)"text"(omf::off)`, and a
+# command substitution that prints nothing expands to zero elements, which
+# makes the whole argument disappear. `set_color` prints nothing when there
+# is no usable terminal (TERM unset or dumb, CI, `ssh host cmd`), so each
+# helper ends with `echo` to always yield exactly one element.
 function omf::em
   set_color cyan 2> /dev/null
+  echo
 end
 
 function omf::dim
   set_color 555 2> /dev/null
+  echo
 end
 
 function omf::err
   set_color red --bold 2> /dev/null
+  echo
 end
 
 function omf::under
   set_color --underline 2> /dev/null
+  echo
 end
 
 function omf::off
   set_color normal 2> /dev/null
+  echo
 end
 
 autoload $path/functions/{compat,core,index,packages,themes,bundle,util,repo,cli,search}

--- a/pkg/omf/spec/basic_spec.fish
+++ b/pkg/omf/spec/basic_spec.fish
@@ -1,51 +1,47 @@
 function describe_basic_tests
-  function before_all
-    set -gx CI WORKAROUND
-  end
-
-  function before_all
-    set -e CI
-  end
-
   function it_has_a_help_command
     set -l output (omf help)
-    echo $output | grep -Eq "cd.+Change to root or package directory"
-    echo $output | grep -Eq "channel.+Get or change the update channel"
-    echo $output | grep -Eq "describe.+Show information about a package"
-    echo $output | grep -Eq "destroy.+Uninstall Oh My Fish"
-    echo $output | grep -Eq "doctor.+Troubleshoot Oh My Fish"
-    echo $output | grep -Eq "help.+Shows help about a command"
-    echo $output | grep -Eq "install.+Install one or more packages"
-    echo $output | grep -Eq "list.+List installed packages"
-    echo $output | grep -Eq "new.+Create a new package from a template"
-    echo $output | grep -Eq "reload.+Reload the current shell"
-    echo $output | grep -Eq "remove.+Remove a package"
-    echo $output | grep -Eq "repositories.+Manage package repositories"
-    echo $output | grep -Eq "search.+Search for a package or theme"
-    echo $output | grep -Eq "theme.+Activate and list available themes"
-    echo $output | grep -Eq "update.+Update Oh My Fish"
-    echo $output | grep -Eq "version.+Display version and exit"
-    assert 0 = $status
+    assert_exit_code 0
+    # Help output highlights the short alias of each command with color
+    # codes (e.g. "d" in "describe"); strip them (including the terminfo
+    # reset "\e(B" some terminals emit) before matching.
+    set -l output (string replace -ra '\e(\[[0-9;]*m|\(B)' '' -- $output)
+    assert_match "cd.+Change to root or package directory" "$output"
+    assert_match "channel.+Get or change the update channel" "$output"
+    assert_match "describe.+Show information about a package" "$output"
+    assert_match "destroy.+Uninstall Oh My Fish" "$output"
+    assert_match "doctor.+Troubleshoot Oh My Fish" "$output"
+    assert_match "help.+Shows help about a command" "$output"
+    assert_match "install.+Install one or more packages" "$output"
+    assert_match "list.+List installed packages" "$output"
+    assert_match "new.+Create a new package from a template" "$output"
+    assert_match "reload.+Reload the current shell" "$output"
+    assert_match "remove.+Remove a package" "$output"
+    assert_match "repositories.+Manage package repositories" "$output"
+    assert_match "search.+Search for a package or theme" "$output"
+    assert_match "theme.+Activate and list available themes" "$output"
+    assert_match "update.+Update Oh My Fish" "$output"
+    assert_match "version.+Display version and exit" "$output"
   end
 
   function it_has_a_doctor_command
     set -l output (omf doctor)
-    assert 0 = $status
-    assert -n (echo $output | grep "Oh My Fish version")
-    assert -n (echo $output | grep "Checking for a sane environment...")
+    assert_exit_code 0
+    assert_match "Oh My Fish version" "$output"
+    assert_match "Checking for a sane environment..." "$output"
   end
 
   function it_installs_packages
     set -l remove_output (omf remove apt 2> /dev/null)
     set -l install_output (omf install apt)
-    assert 0 = $status
-    assert -n (echo $install_output | grep "apt successfully installed.")
+    assert_exit_code 0
+    assert_match "apt successfully installed." "$install_output"
   end
 
   function it_removes_packages
     set -l install_output (omf install apt 2> /dev/null)
     set -l remove_output (omf remove apt)
-    assert 0 = $status
-    assert -n (echo $remove_output | grep -q "apt successfully removed.")
+    assert_exit_code 0
+    assert_match "apt successfully removed." "$remove_output"
   end
 end

--- a/pkg/omf/spec/omf_colors_spec.fish
+++ b/pkg/omf/spec/omf_colors_spec.fish
@@ -1,0 +1,16 @@
+function describe_omf_colors
+  function it_keeps_messages_when_there_is_no_terminal
+    # A command substitution that prints nothing expands to zero elements
+    # and swallows the whole argument, so the helpers must always print.
+    for term in "" dumb
+      set -l output (env TERM=$term fish -c 'echo (omf::em)"em"(omf::off) (omf::err)"err"(omf::off) (omf::dim)"dim"(omf::off) (omf::under)"under"(omf::off)' 2>/dev/null | string replace -ra '\e(\[[0-9;]*m|\(B)' '')
+      assert_equal "em err dim under" "$output"
+    end
+  end
+
+  function it_prints_headings_without_a_terminal
+    set -l output (env TERM=dumb fish -c 'omf list' 2>/dev/null | string replace -ra '\e(\[[0-9;]*m|\(B)' '')
+    assert_match 'Plugins' "$output"
+    assert_match 'Themes' "$output"
+  end
+end

--- a/pkg/omf/spec/omf_list_spec.fish
+++ b/pkg/omf/spec/omf_list_spec.fish
@@ -1,12 +1,4 @@
 function describe_omf_list_tests
-  function before_all
-    set -gx CI WORKAROUND
-  end
-
-  function before_all
-    set -e CI
-  end
-
   function it_can_list_plugins
     set -l list_output (omf list -p)
     assert 0 = $status
@@ -19,18 +11,12 @@ function describe_omf_list_tests
     assert "$list_output" = "default"
   end
 
-  function it_can_list_insttalled_plugins
+  function it_can_list_installed_plugins
     set -l output (omf remove apt 2> /dev/null)
     set -l output (omf install apt 2> /dev/null)
     set -l list_output (omf list -p)
     assert 0 = $status
     assert "$list_output" = "apt		fish-spec	omf"
     set -l output (omf remove apt 2> /dev/null)
-  end
-
-  function it_can_list_themes
-    set -l list_output (omf list -t)
-    assert 0 = $status
-    assert "$list_output" = "default"
   end
 end

--- a/pkg/omf/spec/omf_packages_spec.fish
+++ b/pkg/omf/spec/omf_packages_spec.fish
@@ -1,12 +1,4 @@
 function describe_omf_packages_tests
-  function before_all
-    set -gx CI WORKAROUND
-  end
-
-  function before_all
-    set -e CI
-  end
-
   function it_can_extract_name_from_name
     set -l output (omf.packages.name foo)
     assert 0 = $status

--- a/tests/run.fish
+++ b/tests/run.fish
@@ -1,26 +1,67 @@
 #!/usr/bin/env fish
+#
+# Run the Oh My Fish test suite in an isolated sandbox.
+#
+# A throwaway HOME (plus XDG_* directories) is created, Oh My Fish is
+# installed into it from this checkout, and the smoke tests and fish-spec
+# suites run against that installation. The user's real Oh My Fish
+# configuration is never read or modified.
+#
+# Usage: tests/run.fish [spec files...]
+#   With no arguments, runs every spec under pkg/{fish-spec,omf}/spec.
 
-# TODO: This is only a basic draft.
-
+set -l repo (cd (dirname (status -f))/..; and pwd)
+set -l sandbox (mktemp -d)
 set -l return_code 0
 
-omf list | grep apt 2>&1 >/dev/null
-set -l apt_installed_previously $status
-
-if test $apt_installed_previously -eq 0
-  omf remove apt
+function __omf_tests_cleanup --on-event omf_tests_done -V sandbox
+  command rm -rf "$sandbox"
 end
 
-set commands "omf help" "omf doctor" "omf install apt"
-for cmd in $commands
+# Redirect every path Oh My Fish and fish itself may touch into the sandbox.
+set -lx HOME "$sandbox"
+set -lx XDG_CONFIG_HOME "$sandbox/.config"
+set -lx XDG_DATA_HOME "$sandbox/.local/share"
+set -lx XDG_CACHE_HOME "$sandbox/.cache"
+set -e OMF_PATH
+set -e OMF_CONFIG
+
+echo "Sandbox: $sandbox"
+
+if not fish "$repo/bin/install" --offline="$repo" --noninteractive --yes
+  echo "Failed to install Oh My Fish into the sandbox" >&2
+  emit omf_tests_done
+  exit 1
+end
+
+# Every command below runs in a fresh fish that boots from the sandbox
+# config, exactly as a user's shell would. An offline install skips the
+# bundle, so `omf install` first fetches the default theme.
+set -l smoke_commands "omf install" "omf help" "omf doctor" "omf install apt" "omf remove apt"
+for cmd in $smoke_commands
   echo \$ $cmd
-  if not eval $cmd
+  if not fish -c "$cmd"
+    echo "Smoke test failed: $cmd" >&2
     set return_code 1
   end
 end
 
-if test $apt_installed_previously -ne 0
-  omf remove apt
+set -l specs
+for spec in $argv
+  # Absolute paths, so they resolve the same way inside the sandboxed shell.
+  set specs $specs (cd (dirname $spec); and pwd)/(basename $spec)
+end
+if test (count $specs) -eq 0
+  set specs $repo/pkg/{fish-spec,omf}/spec/*_spec.fish
 end
 
+# `fish -c` only receives positional arguments as $argv since fish 3.1, so
+# hand the file list over through a file instead.
+printf '%s\n' $specs > "$sandbox/specs"
+set -lx OMF_TEST_SPECS_FILE "$sandbox/specs"
+if not fish -c 'fish-spec (cat $OMF_TEST_SPECS_FILE)'
+  set return_code 1
+end
+
+emit omf_tests_done
 exit $return_code


### PR DESCRIPTION
# Description

The bundled test framework was a no-op. `assert` collapsed its arguments into one quoted string, so `assert 1 = 2` ran `test '1 = 2'` — a one-argument string test that is always true. Every assertion in `pkg/omf/spec/` has passed unconditionally since the fish-spec rewrite (#955).

Also fixed:
- `assert_match` was defined twice; the second definition inverted it (now `assert_not_match`).
- `assert_directory_exists` / `assert_file_empty` referenced undefined variables and always passed.
- `assert_exit_code` read `$status` after the previous assertion had clobbered it.
- Runner: `2>1` typo created a file named `1`; per-file counters were accumulated once per `describe` block.

Every helper now runs its check directly and hands `$status` to a shared recorder — no more `eval` on interpolated arguments. New self-tests exercise each helper in both directions; a deliberately failing spec now exits 1.

This PR also carries the isolated test harness (formerly #967): `tests/run.fish` installs Oh My Fish into a throwaway HOME and runs every suite there, so CI and specs never touch a real `~/.config/omf`; the omf specs are fixed to actually assert. The harness now also fails loudly when a spec file is missing, cannot be loaded, or no assertions ran.

Part 1 of the stack: #969 (CLI fixes) → #968 (CI matrix) → #970 (installer) → #971 (self-healing prompt + doctor --fix).

Also included here, because the real assertions expose it on the existing 3.x matrix: `echo (omf::em)"text"(omf::off)` is a cartesian product, and `set_color` prints nothing without a terminal (CI, `ssh host cmd`), so every highlighted omf message silently vanished on fish 3.2–4.0. The colour helpers now always yield one element.

**Environment report**

```
OS type:              Darwin (macOS 27)
Fish version:         fish, version 4.8.1
Git version:          git version 2.55.0
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes

https://claude.ai/code/session_01CbqrmCn2mDNML6uRTaZVEw