### PR TITLE
ci: test fish 4.1–4.8, add lint job, refresh runners

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -8,12 +8,6 @@ runs:
       if: runner.os == 'macOS'
       run: brew update && brew install fish
 
-    - name: Install Oh My Fish!
+    - name: Run tests
       shell: bash
-      run: fish bin/install --verbose --offline --noninteractive --yes
-
-    - name: Run tests on latest fish
-      shell: bash
-      run: |
-        tests/run.fish
-        fish -c 'fish-spec pkg/{fish-spec,omf}/spec/*_spec.fish'
+      run: tests/run.fish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,36 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ohmyfish/fish:4.8.0
+      options: --user root
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v7
+
+      - name: Check fish syntax
+        shell: bash
+        # `fish --no-execute` only checks its first argument, so check one file per call.
+        run: |
+          find . -name '*.fish' -not -path './.git/*' -print0 | xargs -0 -n1 fish --no-execute
+          fish --no-execute bin/install
+
+      - name: Verify installer checksum
+        shell: bash
+        run: cd bin && sha256sum --check install.sha256
+
   build-linux:
     strategy:
       fail-fast: false
@@ -22,14 +51,33 @@ jobs:
           - '3.5.1'
           - '3.6.4'
           - '3.7.1'
-          - '4.0.0'
+          - '4.0.2'
+          - '4.1.2'
+          - '4.2.1'
+          - '4.3.3'
+          - '4.4.0'
+          - '4.5.0'
+          - '4.6.0'
+          - '4.7.1'
+          - '4.8.0'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     container:
       image: ohmyfish/fish:${{ matrix.fish }}
       options: --user root
     steps:
+      # The images for fish >= 4.1 are Alpine based and ship without git.
+      # Install it before checkout, or actions/checkout falls back to a
+      # tarball download and the tests run against a checkout with no .git.
+      - name: Install Git
+        run: |
+          command -v git && exit 0
+          if command -v apk; then apk add --no-cache git
+          elif command -v apt-get; then apt-get update && apt-get install -y git
+          fi
+
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run tests
         uses: ./.github/actions/run-tests
@@ -39,13 +87,13 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
-          - macos-14
           - macos-15
+          - macos-26
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run tests
         uses: ./.github/actions/run-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ohmyfish/fish:2.5.0
+FROM ohmyfish/fish:4.8.0
 
 COPY . /src/oh-my-fish
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ like so: `fish-spec tests/test_*.fish other-tests/foo.fish`
 For syntax and available assertions see the tests for the fish-spec package in
 [pkg/fish-spec/spec/](https://github.com/oh-my-fish/oh-my-fish/tree/master/pkg/fish-spec/spec).
 
+To run Oh My Fish's own test suite, use `tests/run.fish`. It installs Oh My Fish into a temporary sandbox
+(a throwaway `HOME`), so your real configuration is never touched, then runs the smoke tests and every
+`spec/*_spec.fish` under `pkg/`. Pass spec files as arguments to run a subset.
+
 ## Creating Packages
 
 Oh My Fish uses an advanced and well defined plugin architecture to ease plugin development, including init/uninstall hooks, function and completion autoloading. [See the packages documentation](docs/en-US/Packages.md) for more details.

--- a/pkg/fish-spec/framework/assertions.fish
+++ b/pkg/fish-spec/framework/assertions.fish
@@ -1,180 +1,168 @@
-function __fish_spec_assert_generic -a first second success_template failure_template test_command
+# Record the outcome of an assertion.
+#
+# Every assert_* helper runs its check directly and passes the resulting
+# $status here together with a success and a failure message. No `eval` is
+# involved, so assertion arguments containing quotes, parentheses or regex
+# metacharacters are never re-parsed as fish code.
+function __fish_spec_assert_result -a result success_message failure_message
   set __fish_spec_total_assertions_in_file (math $__fish_spec_total_assertions_in_file + 1)
 
-  if eval not "$test_command"
+  if test "$result" -ne 0
     set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file + 1)
     set __fish_spec_last_assertion_failed yes
-    eval __fish_spec.color.echo.failure "$failure_template"
+    __fish_spec.color.echo.failure "$failure_message"
     return 1
   end
   if test "$FISH_SPEC_VERBOSE" = 1
-    eval __fish_spec.color.echo.success "$success_template"
+    __fish_spec.color.echo.success "$success_message"
   end
+  return 0
 end
 
+# assert <test arguments...>
+# Passes each argument to `test` separately, e.g. `assert 1 = 2`.
 function assert
-  set -l first "$argv"
-  __fish_spec_assert_generic \
-    $first unused \
-    'Assertion \"test $first\" passed!' \
-    'Assertion failed: \"test $first\" evaluated to false.' \
-    "test '$argv'"
-    return $status
+  test $argv
+  __fish_spec_assert_result $status \
+    "Assertion \"test $argv\" passed!" \
+    "Assertion failed: \"test $argv\" evaluated to false."
 end
 
-function assert_equal -a first second
-  __fish_spec_assert_generic \
-    $first $second \
-    'Assertion \"$first\" == \"$second\" passed!' \
-    'Assertion failed: Expected \"$first\", but got \"$second\".' \
-    'test "$first" = "$second"'
+function assert_equal -a expected actual
+  test "$expected" = "$actual"
+  __fish_spec_assert_result $status \
+    "Assertion \"$expected\" == \"$actual\" passed!" \
+    "Assertion failed: Expected \"$expected\", but got \"$actual\"."
 end
 
-function assert_not_equal -a first second
-  __fish_spec_assert_generic \
-    $first $second \
-    'Assertion \"$first\" != \"$second\" passed!' \
-    'Assertion failed: Expected \"$second\" to be different from \"$expecte\".' \
-    'test "$first" != "$second"'
+function assert_not_equal -a expected actual
+  test "$expected" != "$actual"
+  __fish_spec_assert_result $status \
+    "Assertion \"$expected\" != \"$actual\" passed!" \
+    "Assertion failed: Expected \"$actual\" to be different from \"$expected\"."
 end
 
+# assert_exit_code <expected>
+# Checks the exit status of the command that ran immediately before it.
 function assert_exit_code -a expected_status
-  __fish_spec_assert_generic \
-    $expected_status $status \
-    'Assertion exit code $second == $first passed!' \
-    'Assertion failed: Expected exit code $first, but got $second.' \
-    'test "$first" -eq "$second"'
+  set -l actual_status $status
+  test "$expected_status" -eq "$actual_status"
+  __fish_spec_assert_result $status \
+    "Assertion exit code $actual_status == $expected_status passed!" \
+    "Assertion failed: Expected exit code $expected_status, but got $actual_status."
 end
 
 function assert_ok
-  assert_exit_code 0
+  set -l actual_status $status
+  test "$actual_status" -eq 0
+  __fish_spec_assert_result $status \
+    "Assertion exit code $actual_status == 0 passed!" \
+    "Assertion failed: Expected exit code 0, but got $actual_status."
 end
 
 function assert_true -a condition
-  __fish_spec_assert_generic \
-    $condition 0 \
-    'Assertion \"$first\" is true passed!' \
-    'Assertion failed: Expected true, but got \"$first\".' \
-    'test $first'
+  test -n "$condition" -a "$condition" != 0 -a "$condition" != false
+  __fish_spec_assert_result $status \
+    "Assertion \"$condition\" is true passed!" \
+    "Assertion failed: Expected true, but got \"$condition\"."
 end
 
 function assert_false -a condition
-  __fish_spec_assert_generic \
-    $condition 0 \
-    'Assertion \"$first\" is false passed!' \
-    'Assertion failed: Expected false, but got \"$first\".' \
-    'test ! $first'
+  test -z "$condition" -o "$condition" = 0 -o "$condition" = false
+  __fish_spec_assert_result $status \
+    "Assertion \"$condition\" is false passed!" \
+    "Assertion failed: Expected false, but got \"$condition\"."
 end
 
 function assert_match -a pattern string
-  __fish_spec_assert_generic \
-    $pattern $string \
-    'Assertion string \"$string\" matches pattern \"$pattern\" passed!' \
-    'Assertion failed: string \"$second\" does not match pattern \"$first\".' \
-    'string match -qr $first $second'
+  string match -qr -- "$pattern" "$string"
+  __fish_spec_assert_result $status \
+    "Assertion string \"$string\" matches pattern \"$pattern\" passed!" \
+    "Assertion failed: string \"$string\" does not match pattern \"$pattern\"."
 end
 
-
-function assert_match -a pattern string
-  __fish_spec_assert_generic \
-    $pattern $string \
-    'Assertion string \"$string\" does not match pattern \"$pattern\" passed!' \
-    'Assertion failed: string \"$second\" does not match pattern \"$first\".' \
-    'not string match -qr $first $second'
+function assert_not_match -a pattern string
+  not string match -qr -- "$pattern" "$string"
+  __fish_spec_assert_result $status \
+    "Assertion string \"$string\" does not match pattern \"$pattern\" passed!" \
+    "Assertion failed: string \"$string\" matches pattern \"$pattern\"."
 end
 
 function assert_file_exists -a file
-  __fish_spec_assert_generic \
-    $file unused \
-    'Assertion file \"$first\" exists passed!' \
-    'Assertion failed: File \"$first\" does not exist.' \
-    'test -f $first'
+  test -f "$file"
+  __fish_spec_assert_result $status \
+    "Assertion file \"$file\" exists passed!" \
+    "Assertion failed: File \"$file\" does not exist."
 end
 
 function assert_file_does_not_exist -a file
-  __fish_spec_assert_generic \
-    $file unused \
-    'Assertion file \"$first\" does not exist passed!' \
-    'Assertion failed: File \"$first\" exists.' \
-    'not test -f $first'
+  not test -f "$file"
+  __fish_spec_assert_result $status \
+    "Assertion file \"$file\" does not exist passed!" \
+    "Assertion failed: File \"$file\" exists."
 end
 
 function assert_directory_exists -a dir
-  __fish_spec_assert_generic \
-    $dir unused \
-    'Assertion directory \"$first\" exists passed!' \
-    'Assertion failed: Directory \"$first\" does not exist.' \
-    'test -d $dir'
+  test -d "$dir"
+  __fish_spec_assert_result $status \
+    "Assertion directory \"$dir\" exists passed!" \
+    "Assertion failed: Directory \"$dir\" does not exist."
 end
 
-function assert_directory_does_not_exist -a file
-  __fish_spec_assert_generic \
-    $file unused \
-    'Assertion directory \"$first\" does not exist passed!' \
-    'Assertion failed: Directory \"$first\" exists.' \
-    'not test -d $first'
+function assert_directory_does_not_exist -a dir
+  not test -d "$dir"
+  __fish_spec_assert_result $status \
+    "Assertion directory \"$dir\" does not exist passed!" \
+    "Assertion failed: Directory \"$dir\" exists."
 end
 
 function assert_file_empty -a file
-  __fish_spec_assert_generic \
-    $file unused \
-    'Assertion file $first is empty passed!' \
-    'Assertion failed: File \"$first\" is not empty.' \
-    'not test -s $file'
+  not test -s "$file"
+  __fish_spec_assert_result $status \
+    "Assertion file \"$file\" is empty passed!" \
+    "Assertion failed: File \"$file\" is not empty."
 end
 
 function assert_file_contains -a file content
-  __fish_spec_assert_generic \
-    $file $content \
-    'Assertion $first contains \"$second\" passed!' \
-    'Assertion failed: File \"$first\" does not contain \"$second\".' \
-    'grep -q "$second" $first'
+  grep -qF -- "$content" "$file"
+  __fish_spec_assert_result $status \
+    "Assertion $file contains \"$content\" passed!" \
+    "Assertion failed: File \"$file\" does not contain \"$content\"."
 end
 
 function assert_file_contains_regex -a file pattern
-  __fish_spec_assert_generic \
-    $file $pattern \
-    'Assertion $first content matches regex \"$second\" passed!' \
-    'Assertion failed: File \"$first\" does not contain a string matching the pattern \"$second\".' \
-    'grep -qE "$second" $first'
+  grep -qE -- "$pattern" "$file"
+  __fish_spec_assert_result $status \
+    "Assertion $file content matches regex \"$pattern\" passed!" \
+    "Assertion failed: File \"$file\" does not contain a string matching the pattern \"$pattern\"."
 end
 
 function assert_not_file_contains -a file content
-  __fish_spec_assert_generic \
-    $file $content \
-    'Assertion $first does not contain \"$content\" passed!' \
-    'Assertion failed: File \"$first\" contains \"$second\".' \
-    'not grep -q "$second" $first'
+  not grep -qF -- "$content" "$file"
+  __fish_spec_assert_result $status \
+    "Assertion $file does not contain \"$content\" passed!" \
+    "Assertion failed: File \"$file\" contains \"$content\"."
 end
 
 function assert_not_file_contains_regex -a file pattern
-  __fish_spec_assert_generic \
-    $file $pattern \
-    'Assertion $first content does not match regex \"$second\" passed!' \
-    'Assertion failed: File \"$first\" contains a string matching the pattern \"$second\".' \
-    'not grep -qE "$second" $first'
+  not grep -qE -- "$pattern" "$file"
+  __fish_spec_assert_result $status \
+    "Assertion $file content does not match regex \"$pattern\" passed!" \
+    "Assertion failed: File \"$file\" contains a string matching the pattern \"$pattern\"."
 end
 
 function assert_in_array -a value
-  set -g __fish_spec_assertion_array $argv[2..-1]
-  __fish_spec_assert_generic \
-    $value "$__fish_spec_assertion_array" \
-    'Assertion \"$first\" in [$second] passed!' \
-    'Assertion failed: Value \"$first\" is not in the array [$second].' \
-    'contains -- $first $__fish_spec_assertion_array'
-  set result $status
-  set -e __fish_spec_assertion_array
-  return $result
+  set -l array $argv[2..-1]
+  contains -- "$value" $array
+  __fish_spec_assert_result $status \
+    "Assertion \"$value\" in [$array] passed!" \
+    "Assertion failed: Value \"$value\" is not in the array [$array]."
 end
 
 function assert_not_in_array -a value
-  set -g __fish_spec_assertion_array $argv[2..-1]
-  __fish_spec_assert_generic \
-    $value "$__fish_spec_assertion_array" \
-    'Assertion \"$first\" not in [$second] passed!' \
-    'Assertion failed: Value \"$first\" is in the array [$second].' \
-    'not contains -- $first $__fish_spec_assertion_array'
-  set result $status
-  set -e __fish_spec_assertion_array
-  return $result
+  set -l array $argv[2..-1]
+  not contains -- "$value" $array
+  __fish_spec_assert_result $status \
+    "Assertion \"$value\" not in [$array] passed!" \
+    "Assertion failed: Value \"$value\" is in the array [$array]."
 end

--- a/pkg/fish-spec/framework/assertions.fish
+++ b/pkg/fish-spec/framework/assertions.fish
@@ -74,14 +74,19 @@ function assert_false -a condition
     "Assertion failed: Expected false, but got \"$condition\"."
 end
 
-function assert_match -a pattern string
+# assert_match <pattern> <string>...
+# Everything after the pattern is joined with spaces, so an unquoted
+# multi-line command substitution is matched as a whole.
+function assert_match -a pattern
+  set -l string "$argv[2..-1]"
   string match -qr -- "$pattern" "$string"
   __fish_spec_assert_result $status \
     "Assertion string \"$string\" matches pattern \"$pattern\" passed!" \
     "Assertion failed: string \"$string\" does not match pattern \"$pattern\"."
 end
 
-function assert_not_match -a pattern string
+function assert_not_match -a pattern
+  set -l string "$argv[2..-1]"
   not string match -qr -- "$pattern" "$string"
   __fish_spec_assert_result $status \
     "Assertion string \"$string\" does not match pattern \"$pattern\" passed!" \

--- a/pkg/fish-spec/functions/fish-spec.fish
+++ b/pkg/fish-spec/functions/fish-spec.fish
@@ -15,7 +15,17 @@ function fish-spec
     set test_files $argv
   end
 
+  if not set -q test_files[1]
+    __fish_spec.color.echo.failure "fish-spec: no spec files found"
+    return 1
+  end
+
   for test_file in $test_files
+    if not test -f $test_file
+      __fish_spec.color.echo.failure "fish-spec: no such spec file: $test_file"
+      set __fish_spec_failed_assertions (math $__fish_spec_failed_assertions + 1)
+      continue
+    end
     __fish_spec_run_tests_in_file $test_file
   end
 
@@ -34,7 +44,12 @@ function __fish_spec_run_tests_in_file -a test_file
   set -g __fish_spec_last_assertion_failed no
 
   __fish_spec.color.echo.info "Running tests in $test_file..."
+  # fish < 4 returns non-zero when sourcing an empty file; that is not an error.
   source $test_file
+  if test $status -ne 0 -a -s $test_file
+    __fish_spec.color.echo.failure "fish-spec: could not load $test_file"
+    set __fish_spec_failed_assertions_in_file 1
+  end
 
   for suite in (functions | string match -r '^describe_.*')
     __fish_spec_run_tests_in_suite $suite

--- a/pkg/fish-spec/functions/fish-spec.fish
+++ b/pkg/fish-spec/functions/fish-spec.fish
@@ -29,6 +29,11 @@ function fish-spec
     __fish_spec_run_tests_in_file $test_file
   end
 
+  if test $__fish_spec_total_assertions -eq 0
+    __fish_spec.color.echo.failure "fish-spec: no assertions ran"
+    set __fish_spec_failed_assertions 1
+  end
+
   # Global summary
   echo
   __fish_spec.color.echo.autocolor $__fish_spec_total_assertions $__fish_spec_failed_assertions "Test complete: $__fish_spec_total_assertions assertions run, $__fish_spec_failed_assertions failed."

--- a/pkg/fish-spec/functions/fish-spec.fish
+++ b/pkg/fish-spec/functions/fish-spec.fish
@@ -42,6 +42,9 @@ function __fish_spec_run_tests_in_file -a test_file
 
   functions -e (functions | string match -r '^(describe_.*)$')
 
+  set __fish_spec_failed_assertions (math $__fish_spec_failed_assertions + $__fish_spec_failed_assertions_in_file)
+  set __fish_spec_total_assertions (math $__fish_spec_total_assertions + $__fish_spec_total_assertions_in_file)
+
   # File-level summary
   echo
   __fish_spec.color.echo.autocolor $__fish_spec_total_assertions_in_file $__fish_spec_failed_assertions_in_file "Summary for $test_file: $__fish_spec_total_assertions_in_file assertions, $__fish_spec_failed_assertions_in_file failed."
@@ -60,9 +63,6 @@ function __fish_spec_run_tests_in_suite -a suite
     __fish_spec_run_test_function $test_func
   end
 
-  set __fish_spec_failed_assertions (math $__fish_spec_failed_assertions + $__fish_spec_failed_assertions_in_file)
-  set __fish_spec_total_assertions (math $__fish_spec_total_assertions + $__fish_spec_total_assertions_in_file)
-
   if functions --query after_all
     after_all
   end
@@ -77,7 +77,7 @@ function __fish_spec_run_test_function -a test_func
 
   set -l before_each_output ""
   if functions --query before_each
-    before_each 2>1 | while read -l line; test -z "$before_each_output" && set before_each_output $line || set before_each_output $before_each_output\n$line; end
+    before_each 2>&1 | while read -l line; test -z "$before_each_output" && set before_each_output $line || set before_each_output $before_each_output\n$line; end
   end
 
   set -l test_func_output ""

--- a/pkg/fish-spec/spec/assertions_spec.fish
+++ b/pkg/fish-spec/spec/assertions_spec.fish
@@ -1,4 +1,7 @@
 function __fish_spec_undo_expected_failure
+  # Only undo when the preceding `assert_exit_code 1` succeeded, i.e. the
+  # assertion under test really did fail. Otherwise the failure is real.
+  test $status -eq 0; or return 1
   set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
   set __fish_spec_last_assertion_failed no
 end
@@ -68,6 +71,27 @@ function describe_assertions
     assert_not_match '^abc' abcdef
     assert_exit_code 1
     __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_match_joins_multiple_arguments
+    set -l lines first second third
+    assert_match 'second' $lines
+    assert_exit_code 0
+    assert_match '^first second third$' $lines
+    assert_exit_code 0
+  end
+
+  function it_does_not_undo_a_real_failure
+    set -l failed_before $__fish_spec_failed_assertions_in_file
+    assert 1 = 1
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+    assert_exit_code 1
+    # The wrongly expected failure above is genuine and must remain counted.
+    assert_equal (math $failed_before + 1) $__fish_spec_failed_assertions_in_file
+    # Undo it for real now that the bookkeeping has been verified.
+    set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
+    set __fish_spec_last_assertion_failed no
   end
 
   function it_assert_match_treats_arguments_as_data

--- a/pkg/fish-spec/spec/assertions_spec.fish
+++ b/pkg/fish-spec/spec/assertions_spec.fish
@@ -1,0 +1,141 @@
+function __fish_spec_undo_expected_failure
+  set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
+  set __fish_spec_last_assertion_failed no
+end
+
+function describe_assertions
+  function before_all
+    set -g __spec_tmp (mktemp -d)
+    echo "hello world" > $__spec_tmp/full
+    touch $__spec_tmp/empty
+  end
+
+  function after_all
+    rm -rf $__spec_tmp
+    set -e __spec_tmp
+  end
+
+  function it_assert_passes_arguments_separately
+    assert 1 = 2
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+
+    assert -n ""
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+
+    assert -z ""
+    assert_exit_code 0
+  end
+
+  function it_assert_equal_and_not_equal
+    assert_equal abc abc
+    assert_exit_code 0
+    assert_not_equal abc abd
+    assert_exit_code 0
+
+    assert_equal abc abd
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+    assert_not_equal abc abc
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_exit_code_reads_previous_status
+    false
+    assert_exit_code 1
+    true
+    assert_ok
+    sh -c 'exit 7'
+    assert_exit_code 7
+
+    false
+    assert_ok
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_match_and_not_match
+    assert_match '^abc' abcdef
+    assert_exit_code 0
+    assert_not_match '^abc' zzz
+    assert_exit_code 0
+
+    assert_match '^abc' zzz
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+    assert_not_match '^abc' abcdef
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_match_treats_arguments_as_data
+    assert_match '\(' 'a(b'
+    assert_exit_code 0
+    assert_match '-x' 'a-x'
+    assert_exit_code 0
+  end
+
+  function it_assert_file_and_directory_helpers
+    assert_file_exists $__spec_tmp/full
+    assert_exit_code 0
+    assert_file_does_not_exist $__spec_tmp/missing
+    assert_exit_code 0
+    assert_directory_exists $__spec_tmp
+    assert_exit_code 0
+    assert_directory_does_not_exist $__spec_tmp/missing
+    assert_exit_code 0
+    assert_file_empty $__spec_tmp/empty
+    assert_exit_code 0
+
+    assert_directory_exists $__spec_tmp/missing
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+    assert_file_empty $__spec_tmp/full
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+    assert_file_exists $__spec_tmp/missing
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_file_contents
+    assert_file_contains $__spec_tmp/full world
+    assert_exit_code 0
+    assert_not_file_contains $__spec_tmp/full mars
+    assert_exit_code 0
+    assert_file_contains_regex $__spec_tmp/full '^hello'
+    assert_exit_code 0
+    assert_not_file_contains_regex $__spec_tmp/full '^world'
+    assert_exit_code 0
+
+    assert_file_contains $__spec_tmp/full mars
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_arrays
+    assert_in_array b a b c
+    assert_exit_code 0
+    assert_not_in_array z a b c
+    assert_exit_code 0
+
+    assert_in_array z a b c
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_assert_true_and_false
+    assert_true 1
+    assert_exit_code 0
+    assert_false 0
+    assert_exit_code 0
+    assert_false ""
+    assert_exit_code 0
+
+    assert_true 0
+    assert_exit_code 1
+    __fish_spec_undo_expected_failure
+  end
+end

--- a/pkg/fish-spec/spec/results_spec.fish
+++ b/pkg/fish-spec/spec/results_spec.fish
@@ -1,8 +1,14 @@
+# Undo the bookkeeping of an assertion that was *expected* to fail, so a
+# deliberately failing assertion does not mark the test or the run as failed.
+function __fish_spec_undo_expected_failure
+  set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
+  set __fish_spec_last_assertion_failed no
+end
+
 function describe_results
   function it_succeeds_when_single_assertion_succeeds
     assert 1 = 1
-
-    assert 0 = $status
+    assert_exit_code 0
   end
 
   function it_succeeds_when_multiple_assertion_succeeds
@@ -11,21 +17,28 @@ function describe_results
   end
 
   function it_fails_when_single_assertion_fails
-    set previous_assertion_counter $__fish_spec_failed_assertions_in_file
+    set -l failed_before $__fish_spec_failed_assertions_in_file
     assert 1 = 2
     assert_exit_code 1
-    echo decrement failed assertion counter so tests pass as expected
-    set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
-    assert_equal $previous_assertion_counter $__fish_spec_failed_assertions_in_file
+    assert_equal (math $failed_before + 1) $__fish_spec_failed_assertions_in_file
+    assert_equal yes $__fish_spec_last_assertion_failed
+    __fish_spec_undo_expected_failure
   end
 
   function it_fails_when_one_of_the_assertions_fails
-    set previous_assertion_counter $__fish_spec_failed_assertions_in_file
+    set -l failed_before $__fish_spec_failed_assertions_in_file
     assert 1 = 2
     assert_exit_code 1
     assert 2 = 2
-    echo decrement failed assertion counter so tests pass as expected
-    set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
-    assert_equal $previous_assertion_counter $__fish_spec_failed_assertions_in_file
+    assert_exit_code 0
+    assert_equal (math $failed_before + 1) $__fish_spec_failed_assertions_in_file
+    __fish_spec_undo_expected_failure
+  end
+
+  function it_counts_every_assertion
+    set -l total_before $__fish_spec_total_assertions_in_file
+    assert 1 = 1
+    assert_equal a a
+    assert_equal (math $total_before + 2) $__fish_spec_total_assertions_in_file
   end
 end

--- a/pkg/fish-spec/spec/results_spec.fish
+++ b/pkg/fish-spec/spec/results_spec.fish
@@ -1,6 +1,9 @@
 # Undo the bookkeeping of an assertion that was *expected* to fail, so a
 # deliberately failing assertion does not mark the test or the run as failed.
 function __fish_spec_undo_expected_failure
+  # Only undo when the preceding `assert_exit_code 1` succeeded, i.e. the
+  # assertion under test really did fail. Otherwise the failure is real.
+  test $status -eq 0; or return 1
   set __fish_spec_failed_assertions_in_file (math $__fish_spec_failed_assertions_in_file - 1)
   set __fish_spec_last_assertion_failed no
 end

--- a/pkg/omf/functions/bundle/omf.bundle.add.fish
+++ b/pkg/omf/functions/bundle/omf.bundle.add.fish
@@ -8,7 +8,7 @@ function omf.bundle.add -a type name_or_url
   set -l record "$type $name_or_url"
 
   if test -f $bundle
-    if not grep $record $bundle > /dev/null 2>&1
+    if not command grep -qxF -- "$record" $bundle
       echo $record >> $bundle
     end
   else

--- a/pkg/omf/functions/bundle/omf.bundle.remove.fish
+++ b/pkg/omf/functions/bundle/omf.bundle.remove.fish
@@ -1,27 +1,28 @@
-function omf.bundle.remove
-    set -l bundle $OMF_CONFIG/bundle
+function omf.bundle.remove -a type name
+  set -l bundle $OMF_CONFIG/bundle
 
-    if test -L $OMF_CONFIG/bundle
-      set bundle (readlink $OMF_CONFIG/bundle)
-    end
-
-    if test -f $bundle
-      set type $argv[1]
-      set name $argv[2]
-      set bundle_contents (cat $bundle | sort -u)
-
-      command rm -f $bundle
-
-      for record in $bundle_contents
-        set record_type (echo $record | cut -d' ' -f1)
-        set record_name_or_url (echo $record | cut -d' ' -f2-)
-        set record_name (omf.packages.name $record_name_or_url)
-
-        if not test "$type" = "$record_type" -a "$name" = "$record_name"
-          echo "$record_type $record_name_or_url" >> $bundle
-        end
-      end
-    end
-
-    return 0
+  if test -L $OMF_CONFIG/bundle
+    set bundle (readlink $OMF_CONFIG/bundle)
   end
+
+  test -f $bundle
+    or return 0
+
+  set -l bundle_contents (cat $bundle | sort -u)
+  set -l tmp "$bundle.tmp"
+
+  # Write the remaining records to a temporary file first, so an interrupted
+  # run never leaves the bundle missing or half written.
+  true > $tmp
+  for record in $bundle_contents
+    set -l record_type (echo $record | cut -d' ' -f1)
+    set -l record_name_or_url (echo $record | cut -d' ' -f2-)
+    set -l record_name (omf.packages.name $record_name_or_url)
+
+    if not test "$type" = "$record_type" -a "$name" = "$record_name"
+      echo "$record_type $record_name_or_url" >> $tmp
+    end
+  end
+
+  command mv "$tmp" "$bundle"
+end

--- a/pkg/omf/functions/cli/omf.cli.install.fish
+++ b/pkg/omf/functions/cli/omf.cli.install.fish
@@ -10,7 +10,9 @@ function omf.cli.install
       or set fail_count 1
   case '*'
     for package in $argv
-      omf.packages.install $package;
+      omf.packages.install $package
+      set -l install_status $status
+      test $install_status -eq 0
         and require $package
 
       # If package is a theme, set it to active.
@@ -21,7 +23,7 @@ function omf.cli.install
         omf.theme.set $themes[$ind]
       end
 
-      test $status != 0;
+      test $install_status -ne 0
         and set fail_count (math $fail_count + 1)
     end
   end

--- a/pkg/omf/functions/cli/omf.cli.list.fish
+++ b/pkg/omf/functions/cli/omf.cli.list.fish
@@ -1,10 +1,10 @@
 function omf.cli.list
   switch (count $argv)
   case 0
-    echo (set_color -u)Plugins(set_color normal)
+    echo (omf::under)Plugins(omf::off)
     omf.packages.list --plugin | column
     echo
-    echo (set_color -u)Themes(set_color normal)
+    echo (omf::under)Themes(omf::off)
     omf.packages.list --theme | column
   case '*'
     omf.packages.list $argv | column

--- a/pkg/omf/functions/cli/omf.cli.list.fish
+++ b/pkg/omf/functions/cli/omf.cli.list.fish
@@ -2,11 +2,11 @@ function omf.cli.list
   switch (count $argv)
   case 0
     echo (omf::under)Plugins(omf::off)
-    omf.packages.list --plugin | column
+    omf.packages.list --plugin | omf.columns
     echo
     echo (omf::under)Themes(omf::off)
-    omf.packages.list --theme | column
+    omf.packages.list --theme | omf.columns
   case '*'
-    omf.packages.list $argv | column
+    omf.packages.list $argv | omf.columns
   end
 end

--- a/pkg/omf/functions/cli/omf.cli.reload.fish
+++ b/pkg/omf/functions/cli/omf.cli.reload.fish
@@ -9,7 +9,7 @@ function omf.cli.reload
 end
 
 function __omf.cli.reload.job_warning
-  echo (set_color -u)"Reload aborted. There are background jobs:"(set_color normal)
+  echo (omf::under)"Reload aborted. There are background jobs:"(omf::off)
   echo
   jobs
   echo

--- a/pkg/omf/functions/cli/omf.cli.theme.fish
+++ b/pkg/omf/functions/cli/omf.cli.theme.fish
@@ -9,10 +9,10 @@ function omf.cli.theme -a name
     set -l highlight_current s/"$regex_current"/"\1"(omf::em)"\2"(omf::off)"\3"/g
 
     echo (omf::under)"Installed:"(omf::off)
-    omf.packages.list --theme | column | sed -E "$highlight_current"
+    omf.packages.list --theme | omf.columns | sed -E "$highlight_current"
     echo
     echo (omf::under)"Available:"(omf::off)
-    omf.index.query --type=theme | column
+    omf.index.query --type=theme | omf.columns
   case 1
     if not omf.theme.set $name
       echo (omf::err)"Theme not installed!"(omf::off)

--- a/pkg/omf/functions/cli/omf.cli.theme.fish
+++ b/pkg/omf/functions/cli/omf.cli.theme.fish
@@ -21,7 +21,7 @@ function omf.cli.theme -a name
     end
   case '*'
     echo (omf::err)"Invalid number of arguments"(omf::off) >&2
-    echo "Usage: $_ "(omf::em)"t"(omf::off)"heme [<theme name>]" >&2
+    echo "Usage: omf "(omf::em)"t"(omf::off)"heme [<theme name>]" >&2
     return $OMF_INVALID_ARG
   end
 end

--- a/pkg/omf/functions/cli/omf.cli.themes.list.fish
+++ b/pkg/omf/functions/cli/omf.cli.themes.list.fish
@@ -7,8 +7,8 @@ function omf.cli.themes.list
   set -l highlight_current s/"$regex_current"/"\1"(omf::em)"\2"(omf::off)"\3"/g
 
   echo (omf::under)"Installed:"(omf::off)
-  omf.packages.list --theme | column | sed -E "$highlight_current"
+  omf.packages.list --theme | omf.columns | sed -E "$highlight_current"
   echo
   echo (omf::under)"Available:"(omf::off)
-  omf.index.query --type=theme | column
+  omf.index.query --type=theme | omf.columns
 end

--- a/pkg/omf/functions/cli/omf.cli.update.fish
+++ b/pkg/omf/functions/cli/omf.cli.update.fish
@@ -13,14 +13,11 @@ function omf.cli.update
 
   if set -q update_core
     omf.core.update
+    set -l core_status $status
 
-    if type -q omf.version
-      set OMF_VERSION (omf.version)
-    end
-
-    if test $status -ne 1
+    if test $core_status -eq 0
       echo (omf::em)"Oh My Fish is up to date."(omf::off)
-      echo (omf::em)"You are now using Oh My Fish version $OMF_VERSION."(omf::off)
+      echo (omf::em)"You are now using Oh My Fish version "(omf.version)"."(omf::off)
     else
       echo (omf::err)"Oh My Fish failed to update."(omf::off)
       echo "Please open a new issue here → "(omf::em)"github.com/oh-my-fish/oh-my-fish/issues"(omf::off)

--- a/pkg/omf/functions/compat/available.fish
+++ b/pkg/omf/functions/compat/available.fish
@@ -1,7 +1,7 @@
 function available
   echo (status -t)[5] | read -la caller
   printf 'warning: function %savailable%s is deprecated and will be removed soon.\n' \
-  (set_color -u) (set_color normal)
+  (omf::under) (omf::off)
 
   contains input $caller
     or echo $caller

--- a/pkg/omf/functions/compat/refresh.fish
+++ b/pkg/omf/functions/compat/refresh.fish
@@ -1,7 +1,7 @@
 function refresh -d "(deprecated) Refresh fish session by replacing current process"
   echo (status -t)[5] | read -la caller
   printf 'warning: function %srefresh%s is deprecated and will be removed soon.\n' \
-  (set_color -u) (set_color normal)
+  (omf::under) (omf::off)
 
   contains input $caller
     or echo $caller

--- a/pkg/omf/functions/core/omf.version.fish
+++ b/pkg/omf/functions/core/omf.version.fish
@@ -1,3 +1,17 @@
 function omf.version
-  command git -C "$OMF_PATH" describe --tags --match 'v*' --always | cut -c 2-
+  set -l omf_version (command git -C "$OMF_PATH" describe --tags --match 'v*' 2> /dev/null)
+  if test -n "$omf_version"
+    string replace -r '^v' '' -- $omf_version
+    return 0
+  end
+
+  # No release tag reachable: fall back to the commit, or "unknown" for a
+  # tarball install without a Git checkout.
+  set -l commit (command git -C "$OMF_PATH" rev-parse --short HEAD 2> /dev/null)
+  if test -n "$commit"
+    echo $commit
+  else
+    echo unknown
+  end
+  return 0
 end

--- a/pkg/omf/functions/index/omf.index.path.fish
+++ b/pkg/omf/functions/index/omf.index.path.fish
@@ -1,5 +1,10 @@
 function omf.index.path -d 'Get the path to the local package index'
-  set -q XDG_CACHE_HOME
-    and echo (echo $XDG_CACHE_HOME | sed 's:/*$::')"/omf"
-    or echo (echo $HOME | sed 's:/*$::')"/.cache/omf"
+  if test -n "$XDG_CACHE_HOME"
+    echo (string trim --right --chars / -- $XDG_CACHE_HOME)"/omf"
+  else if test -n "$HOME"
+    echo (string trim --right --chars / -- $HOME)"/.cache/omf"
+  else
+    echo (omf::err)"Cannot locate the package index: \$HOME is not set."(omf::off) >&2
+    return 1
+  end
 end

--- a/pkg/omf/functions/index/omf.index.repositories.fish
+++ b/pkg/omf/functions/index/omf.index.repositories.fish
@@ -33,16 +33,11 @@ function omf.index.repositories -d 'Manage package repositories'
       set -l repo "$repo_url $repo_branch"
 
       # Check if we already have the repository.
-      if test -f $OMF_CONFIG/repositories
-        if command grep -q $repo $OMF_CONFIG/repositories
+      for file in {$OMF_PATH,$OMF_CONFIG}/repositories
+        if test -f $file; and command grep -qxF -- "$repo" $file
           echo "The repository is already added." >&2
           return 1
         end
-      end
-
-      if command grep -q $repo $OMF_PATH/repositories
-        echo "The repository is already added." >&2
-        return 1
       end
 
       # Before we add, do a quick ls-remote to see if the URL is a valid repo.
@@ -51,6 +46,7 @@ function omf.index.repositories -d 'Manage package repositories'
         return 1
       end
 
+      command mkdir -p $OMF_CONFIG
       echo "$repo" >> $OMF_CONFIG/repositories
 
     case rm remove
@@ -71,16 +67,16 @@ function omf.index.repositories -d 'Manage package repositories'
 
       # Check to see if user has repositories and if the given URL is listed.
       if test -f $OMF_CONFIG/repositories
-        if command grep -q $repo $OMF_CONFIG/repositories
-          command grep -v $repo $OMF_CONFIG/repositories > $OMF_CONFIG/repositories.swp
+        if command grep -qxF -- "$repo" $OMF_CONFIG/repositories
+          command grep -vxF -- "$repo" $OMF_CONFIG/repositories > $OMF_CONFIG/repositories.swp
           command mv $OMF_CONFIG/repositories.swp $OMF_CONFIG/repositories
 
-          return
+          return 0
         end
       end
 
       # The given URL is not listed, check if it is a built-in repository they can't remove.
-      if command grep -q $repo $OMF_PATH/repositories
+      if test -f $OMF_PATH/repositories; and command grep -qxF -- "$repo" $OMF_PATH/repositories
         echo "The repository '$repo' is built-in and cannot be removed." >&2
       else
         echo "Could not find user repository '$repo'" >&2

--- a/pkg/omf/functions/index/omf.index.update.fish
+++ b/pkg/omf/functions/index/omf.index.update.fish
@@ -32,6 +32,7 @@ function omf.index.update -d 'Update package indexes'
     set -l url $repositories[1]
     set -l branch $repositories[2]
     set -l path (omf.index.path)/$repositories[3]
+      or return 1
     set valid_paths $valid_paths $path
 
     echo -n "Updating $url $branch... "
@@ -52,7 +53,10 @@ function omf.index.update -d 'Update package indexes'
   end
 
   # Remove repositories not in the lists.
-  for path in (omf.index.path)/*
+  set -l index_path (omf.index.path)
+    or return 1
+
+  for path in $index_path/*
     if not contains -- $path $valid_paths
       command rm -rf $path
     end

--- a/pkg/omf/functions/packages/omf.packages.list.fish
+++ b/pkg/omf/functions/packages/omf.packages.list.fish
@@ -1,7 +1,5 @@
-set -l builtin_packages {$OMF_PATH,$OMF_CONFIG}/pkg*/{omf,fish-spec}
-
-
 function omf.packages.list -d 'List installed packages'
+  set -l builtin_packages {$OMF_PATH,$OMF_CONFIG}/pkg*/{omf,fish-spec}
   set -l show_plugins
   set -l show_themes
 

--- a/pkg/omf/functions/packages/omf.packages.new.fish
+++ b/pkg/omf/functions/packages/omf.packages.new.fish
@@ -15,6 +15,7 @@ function __omf.packages.new.from_template -a path github user name
       mkdir (basename $file)
       pushd (basename $file)
       __omf.packages.new.from_template $file $github $user $name
+      popd
     else
       set -l target (begin
         if test (basename $file) = "{{NAME}}.fish"
@@ -35,7 +36,6 @@ function __omf.packages.new.from_template -a path github user name
       end)$target
     end
   end
-  popd >/dev/null 2>&1
 end
 
 
@@ -70,6 +70,6 @@ function omf.packages.new -a option name
     echo (omf::em)"Switched to $dir"(omf::off)
   else
     echo (omf::err)"\$OMF_CONFIG and/or \$OMF_PATH undefined."(omf::off) >&2
-    exit $OMF_UNKNOWN_ERR
+    return $OMF_UNKNOWN_ERR
   end
 end

--- a/pkg/omf/functions/packages/omf.packages.remove.fish
+++ b/pkg/omf/functions/packages/omf.packages.remove.fish
@@ -23,12 +23,13 @@ function omf.packages.remove -a pkg
     emit uninstall_$pkg
     emit {$pkg}_uninstall
 
-    if command rm -rf $path
-      omf.bundle.remove "package" $pkg
-      return 0
-    else
-      return 1
-    end
+    command rm -rf $path
+      or return 1
+  end
+
+  if set -q found
+    omf.bundle.remove "package" $pkg
+    return 0
   end
 
   for path in {$OMF_PATH,$OMF_CONFIG}/themes/$pkg
@@ -36,15 +37,17 @@ function omf.packages.remove -a pkg
       and set found;
       or continue
 
-    test $pkg = (cat $OMF_CONFIG/theme);
+    set -l current_theme (cat $OMF_CONFIG/theme 2> /dev/null)
+    test "$pkg" = "$current_theme";
       and echo default > $OMF_CONFIG/theme
 
-    if command rm -rf $path
-      omf.bundle.remove "theme" $pkg
-      return 0
-    else
-      return 1
-    end
+    command rm -rf $path
+      or return 1
+  end
+
+  if set -q found
+    omf.bundle.remove "theme" $pkg
+    return 0
   end
 
   set -q found; or return 2

--- a/pkg/omf/functions/packages/omf.packages.valid_name.fish
+++ b/pkg/omf/functions/packages/omf.packages.valid_name.fish
@@ -1,15 +1,12 @@
 function omf.packages.valid_name -a package
-  test (echo "$package" | tr "[:upper:]" "[:lower:]") = "omf"; and return 10
-  test (echo "$package" | tr "[:upper:]" "[:lower:]") = "default"; and return 10
-  switch $package
-    case {a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z}\*
-      switch $package
-        case "*/*" "* *" "*&*" "*\"*" "*!*" "*&*" "*%*" "*#*"
-          return 10
-        case "*"
-          return 0
-      end
-    case "*"
-      return 10
-  end
+  # Reserved names.
+  contains -- (string lower -- "$package") omf default
+    and return 10
+
+  # A name is a single path component: it starts with a letter or digit and
+  # contains only letters, digits, dots, underscores and dashes.
+  string match -qr -- '^[A-Za-z0-9][A-Za-z0-9._-]*$' "$package"
+    or return 10
+
+  return 0
 end

--- a/pkg/omf/functions/util/omf.check.fish_prompt.fish
+++ b/pkg/omf/functions/util/omf.check.fish_prompt.fish
@@ -1,10 +1,19 @@
+# Succeeds when the user's fish_prompt.fish does not override the active theme.
 function omf.check.fish_prompt
   set -l prompt_file "fish_prompt.fish"
-  set -l theme (cat $OMF_CONFIG/theme)
+  set -l theme (cat $OMF_CONFIG/theme 2> /dev/null)
 
   set -l user_functions_path (omf.xdg.config_home)/fish/functions
-  set -l fish_prompt (readlink "$user_functions_path/$prompt_file" 2> /dev/null)
+  set -l prompt_path "$user_functions_path/$prompt_file"
 
-  not test -e "$fish_prompt"; and return 0
-  contains -- "$fish_prompt" {$OMF_CONFIG,$OMF_PATH}/themes/$theme/$prompt_file
+  if test -L "$prompt_path"
+    # Oh My Fish manages the prompt through a symlink to the theme's file.
+    set -l target (readlink "$prompt_path")
+    contains -- "$target" {$OMF_CONFIG,$OMF_PATH}/themes/$theme/$prompt_file
+  else if test -e "$prompt_path"
+    # A regular file (e.g. written by fish_config) shadows every theme.
+    return 1
+  else
+    return 0
+  end
 end

--- a/pkg/omf/functions/util/omf.check.version.fish
+++ b/pkg/omf/functions/util/omf.check.version.fish
@@ -1,3 +1,8 @@
-function omf.check.version -a min_version -a current_version
-  test (echo "$min_version"\n"$current_version" | tr '.' ' ' | sort -n | head -n1) = (echo "$min_version" | tr '.' ' ')
+# omf.check.version <min_version> <current_version>
+# Succeeds when current_version is at least min_version.
+function omf.check.version -a min_version current_version
+  set -l lowest (printf '%s\n' "$min_version" "$current_version" \
+    | command sort -t . -k 1,1n -k 2,2n -k 3,3n -k 4,4n \
+    | command head -n 1)
+  test "$lowest" = "$min_version"
 end

--- a/pkg/omf/functions/util/omf.columns.fish
+++ b/pkg/omf/functions/util/omf.columns.fish
@@ -1,0 +1,9 @@
+# Lay stdin out in columns like `column`, or pass it through unchanged when
+# `column` (util-linux) is not installed, e.g. on Alpine.
+function omf.columns
+  if type -q column
+    command column
+  else
+    command cat
+  end
+end

--- a/pkg/omf/init.fish
+++ b/pkg/omf/init.fish
@@ -3,24 +3,34 @@ set -g OMF_UNKNOWN_OPT   2
 set -g OMF_INVALID_ARG   3
 set -g OMF_UNKNOWN_ERR   4
 
+# Colour helpers. They are used as `echo (omf::em)"text"(omf::off)`, and a
+# command substitution that prints nothing expands to zero elements, which
+# makes the whole argument disappear. `set_color` prints nothing when there
+# is no usable terminal (TERM unset or dumb, CI, `ssh host cmd`), so each
+# helper ends with `echo` to always yield exactly one element.
 function omf::em
   set_color cyan 2> /dev/null
+  echo
 end
 
 function omf::dim
   set_color 555 2> /dev/null
+  echo
 end
 
 function omf::err
   set_color red --bold 2> /dev/null
+  echo
 end
 
 function omf::under
   set_color --underline 2> /dev/null
+  echo
 end
 
 function omf::off
   set_color normal 2> /dev/null
+  echo
 end
 
 autoload $path/functions/{compat,core,index,packages,themes,bundle,util,repo,cli,search}

--- a/pkg/omf/spec/basic_spec.fish
+++ b/pkg/omf/spec/basic_spec.fish
@@ -1,51 +1,47 @@
 function describe_basic_tests
-  function before_all
-    set -gx CI WORKAROUND
-  end
-
-  function before_all
-    set -e CI
-  end
-
   function it_has_a_help_command
     set -l output (omf help)
-    echo $output | grep -Eq "cd.+Change to root or package directory"
-    echo $output | grep -Eq "channel.+Get or change the update channel"
-    echo $output | grep -Eq "describe.+Show information about a package"
-    echo $output | grep -Eq "destroy.+Uninstall Oh My Fish"
-    echo $output | grep -Eq "doctor.+Troubleshoot Oh My Fish"
-    echo $output | grep -Eq "help.+Shows help about a command"
-    echo $output | grep -Eq "install.+Install one or more packages"
-    echo $output | grep -Eq "list.+List installed packages"
-    echo $output | grep -Eq "new.+Create a new package from a template"
-    echo $output | grep -Eq "reload.+Reload the current shell"
-    echo $output | grep -Eq "remove.+Remove a package"
-    echo $output | grep -Eq "repositories.+Manage package repositories"
-    echo $output | grep -Eq "search.+Search for a package or theme"
-    echo $output | grep -Eq "theme.+Activate and list available themes"
-    echo $output | grep -Eq "update.+Update Oh My Fish"
-    echo $output | grep -Eq "version.+Display version and exit"
-    assert 0 = $status
+    assert_exit_code 0
+    # Help output highlights the short alias of each command with color
+    # codes (e.g. "d" in "describe"); strip them (including the terminfo
+    # reset "\e(B" some terminals emit) before matching.
+    set -l output (string replace -ra '\e(\[[0-9;]*m|\(B)' '' -- $output)
+    assert_match "cd.+Change to root or package directory" "$output"
+    assert_match "channel.+Get or change the update channel" "$output"
+    assert_match "describe.+Show information about a package" "$output"
+    assert_match "destroy.+Uninstall Oh My Fish" "$output"
+    assert_match "doctor.+Troubleshoot Oh My Fish" "$output"
+    assert_match "help.+Shows help about a command" "$output"
+    assert_match "install.+Install one or more packages" "$output"
+    assert_match "list.+List installed packages" "$output"
+    assert_match "new.+Create a new package from a template" "$output"
+    assert_match "reload.+Reload the current shell" "$output"
+    assert_match "remove.+Remove a package" "$output"
+    assert_match "repositories.+Manage package repositories" "$output"
+    assert_match "search.+Search for a package or theme" "$output"
+    assert_match "theme.+Activate and list available themes" "$output"
+    assert_match "update.+Update Oh My Fish" "$output"
+    assert_match "version.+Display version and exit" "$output"
   end
 
   function it_has_a_doctor_command
     set -l output (omf doctor)
-    assert 0 = $status
-    assert -n (echo $output | grep "Oh My Fish version")
-    assert -n (echo $output | grep "Checking for a sane environment...")
+    assert_exit_code 0
+    assert_match "Oh My Fish version" "$output"
+    assert_match "Checking for a sane environment..." "$output"
   end
 
   function it_installs_packages
     set -l remove_output (omf remove apt 2> /dev/null)
     set -l install_output (omf install apt)
-    assert 0 = $status
-    assert -n (echo $install_output | grep "apt successfully installed.")
+    assert_exit_code 0
+    assert_match "apt successfully installed." "$install_output"
   end
 
   function it_removes_packages
     set -l install_output (omf install apt 2> /dev/null)
     set -l remove_output (omf remove apt)
-    assert 0 = $status
-    assert -n (echo $remove_output | grep -q "apt successfully removed.")
+    assert_exit_code 0
+    assert_match "apt successfully removed." "$remove_output"
   end
 end

--- a/pkg/omf/spec/omf_bundle_spec.fish
+++ b/pkg/omf/spec/omf_bundle_spec.fish
@@ -1,0 +1,44 @@
+function describe_omf_bundle
+  function before_all
+    set -g __spec_bundle_backup (mktemp)
+    command cp $OMF_CONFIG/bundle $__spec_bundle_backup
+  end
+
+  function before_each
+    echo "theme default" > $OMF_CONFIG/bundle
+  end
+
+  function after_all
+    command cp $__spec_bundle_backup $OMF_CONFIG/bundle
+    command rm -f $__spec_bundle_backup
+    set -e __spec_bundle_backup
+  end
+
+  function it_adds_a_record_once
+    omf.bundle.add package bass
+    omf.bundle.add package bass
+    assert_equal 1 (grep -c '^package bass$' $OMF_CONFIG/bundle)
+  end
+
+  function it_adds_a_record_that_is_a_prefix_of_an_existing_one
+    omf.bundle.add package bassx
+    omf.bundle.add package bass
+    assert_file_contains_regex $OMF_CONFIG/bundle '^package bass$'
+    assert_file_contains_regex $OMF_CONFIG/bundle '^package bassx$'
+  end
+
+  function it_removes_only_the_matching_record
+    omf.bundle.add package bass
+    omf.bundle.add package bassx
+    omf.bundle.remove package bass
+    assert_not_file_contains_regex $OMF_CONFIG/bundle '^package bass$'
+    assert_file_contains_regex $OMF_CONFIG/bundle '^package bassx$'
+  end
+
+  function it_keeps_an_empty_bundle_file_after_removing_the_last_record
+    echo "package bass" > $OMF_CONFIG/bundle
+    omf.bundle.remove package bass
+    assert_file_exists $OMF_CONFIG/bundle
+    assert_file_empty $OMF_CONFIG/bundle
+  end
+end

--- a/pkg/omf/spec/omf_checks_spec.fish
+++ b/pkg/omf/spec/omf_checks_spec.fish
@@ -1,0 +1,96 @@
+function describe_omf_check_version
+  function it_accepts_equal_and_newer_versions
+    omf.check.version 3.0.0 3.0.0
+    assert_exit_code 0
+    omf.check.version 3.0.0 4.8.1
+    assert_exit_code 0
+    omf.check.version 1.9.5 1.10.0
+    assert_exit_code 0
+    omf.check.version 2.9 2.10
+    assert_exit_code 0
+  end
+
+  function it_rejects_older_versions
+    omf.check.version 3.0.0 2.7.1
+    assert_exit_code 1
+    omf.check.version 1.10.0 1.9.5
+    assert_exit_code 1
+  end
+end
+
+function describe_omf_check_fish_prompt
+  function before_all
+    set -g __spec_prompt (omf.xdg.config_home)/fish/functions/fish_prompt.fish
+    command mkdir -p (dirname $__spec_prompt)
+    set -g __spec_prompt_backup (mktemp)
+    if test -L $__spec_prompt
+      set -g __spec_prompt_was_link (readlink $__spec_prompt)
+    else if test -e $__spec_prompt
+      command cp $__spec_prompt $__spec_prompt_backup
+      set -g __spec_prompt_was_file
+    end
+  end
+
+  function after_all
+    command rm -f $__spec_prompt
+    if set -q __spec_prompt_was_link
+      command ln -s $__spec_prompt_was_link $__spec_prompt
+    else if set -q __spec_prompt_was_file
+      command cp $__spec_prompt_backup $__spec_prompt
+    end
+    command rm -f $__spec_prompt_backup
+    set -e __spec_prompt __spec_prompt_backup __spec_prompt_was_link __spec_prompt_was_file
+  end
+
+  function it_is_healthy_when_no_prompt_file_exists
+    command rm -f $__spec_prompt
+    omf.check.fish_prompt
+    assert_exit_code 0
+  end
+
+  function it_is_healthy_when_prompt_links_to_the_active_theme
+    read -l theme < $OMF_CONFIG/theme
+    command rm -f $__spec_prompt
+    command ln -s $OMF_PATH/themes/$theme/fish_prompt.fish $__spec_prompt
+    omf.check.fish_prompt
+    assert_exit_code 0
+  end
+
+  function it_detects_a_plain_prompt_file_overriding_the_theme
+    command rm -f $__spec_prompt
+    echo 'function fish_prompt; echo "> "; end' > $__spec_prompt
+    omf.check.fish_prompt
+    assert_exit_code 1
+  end
+end
+
+function describe_omf_version
+  function it_prints_a_version_without_a_leading_v
+    set -l omf_version (omf.version)
+    assert_exit_code 0
+    assert_not_match '^v' "$omf_version"
+    assert_not_equal "" "$omf_version"
+  end
+
+  function it_does_not_truncate_a_commit_hash_when_there_are_no_tags
+    set -l head (command git -C $OMF_PATH rev-parse --short HEAD)
+    if test -z (command git -C $OMF_PATH tag -l 'v*' | head -n1)
+      assert_equal $head (omf.version)
+    end
+  end
+end
+
+function describe_omf_index_path
+  function it_ignores_an_empty_xdg_cache_home
+    set -l path (env XDG_CACHE_HOME= fish -c 'omf.index.path')
+    assert_match '/\.cache/omf$' "$path"
+  end
+end
+
+function describe_omf_packages_list
+  function it_hides_builtin_packages
+    set -l plugins (omf.packages.list --plugin)
+    assert_not_in_array omf $plugins
+    assert_not_in_array fish-spec $plugins
+  end
+end

--- a/pkg/omf/spec/omf_cli_spec.fish
+++ b/pkg/omf/spec/omf_cli_spec.fish
@@ -1,0 +1,45 @@
+function describe_omf_new_and_remove
+  function after_all
+    command rm -rf $OMF_CONFIG/pkg/MyPlugin
+    omf.bundle.remove package MyPlugin
+  end
+
+  function it_creates_a_package_with_a_capitalised_name
+    fish -c 'omf new plugin MyPlugin' >/dev/null
+    assert_exit_code 0
+    assert_directory_exists $OMF_CONFIG/pkg/MyPlugin
+    assert_file_exists $OMF_CONFIG/pkg/MyPlugin/init.fish
+  end
+
+  function it_removes_a_package_with_a_capitalised_name
+    test -d $OMF_CONFIG/pkg/MyPlugin; or fish -c 'omf new plugin MyPlugin' >/dev/null
+    set -l output (omf remove MyPlugin)
+    assert_exit_code 0
+    assert_directory_does_not_exist $OMF_CONFIG/pkg/MyPlugin
+  end
+
+  function it_does_not_exit_the_shell_when_paths_are_missing
+    set -l output (fish -c 'cd /; set -x OMF_CONFIG /nonexistent; set -x OMF_PATH /nonexistent; omf.packages.new plugin foo 2>/dev/null; echo survived')
+    assert_equal survived "$output[-1]"
+  end
+end
+
+function describe_omf_theme_cli
+  function it_prints_a_usage_line_with_the_command_name
+    set -l output (omf theme a b 2>&1 | string replace -ra '\e(\[[0-9;]*m|\(B)' '')
+    assert_match 'Usage: omf theme' "$output"
+  end
+end
+
+function describe_omf_install_and_update_exit_codes
+  function it_fails_when_a_package_cannot_be_installed
+    omf install this-package-does-not-exist-omf-spec >/dev/null 2>&1
+    assert_exit_code 1
+  end
+
+  function it_reports_a_failed_core_update
+    set -l output (fish -c 'function omf.core.update; return 1; end; omf update omf 2>&1' | string replace -ra '\e(\[[0-9;]*m|\(B)' '')
+    assert_match 'failed to update' "$output"
+    assert_not_match 'is up to date' "$output"
+  end
+end

--- a/pkg/omf/spec/omf_colors_spec.fish
+++ b/pkg/omf/spec/omf_colors_spec.fish
@@ -1,0 +1,16 @@
+function describe_omf_colors
+  function it_keeps_messages_when_there_is_no_terminal
+    # A command substitution that prints nothing expands to zero elements
+    # and swallows the whole argument, so the helpers must always print.
+    for term in "" dumb
+      set -l output (env TERM=$term fish -c 'echo (omf::em)"em"(omf::off) (omf::err)"err"(omf::off) (omf::dim)"dim"(omf::off) (omf::under)"under"(omf::off)' 2>/dev/null | string replace -ra '\e(\[[0-9;]*m|\(B)' '')
+      assert_equal "em err dim under" "$output"
+    end
+  end
+
+  function it_prints_headings_without_a_terminal
+    set -l output (env TERM=dumb fish -c 'omf list' 2>/dev/null | string replace -ra '\e(\[[0-9;]*m|\(B)' '')
+    assert_match 'Plugins' "$output"
+    assert_match 'Themes' "$output"
+  end
+end

--- a/pkg/omf/spec/omf_list_spec.fish
+++ b/pkg/omf/spec/omf_list_spec.fish
@@ -1,12 +1,4 @@
 function describe_omf_list_tests
-  function before_all
-    set -gx CI WORKAROUND
-  end
-
-  function before_all
-    set -e CI
-  end
-
   function it_can_list_plugins
     set -l list_output (omf list -p)
     assert 0 = $status
@@ -19,18 +11,12 @@ function describe_omf_list_tests
     assert "$list_output" = "default"
   end
 
-  function it_can_list_insttalled_plugins
+  function it_can_list_installed_plugins
     set -l output (omf remove apt 2> /dev/null)
     set -l output (omf install apt 2> /dev/null)
     set -l list_output (omf list -p)
     assert 0 = $status
     assert "$list_output" = "apt		fish-spec	omf"
     set -l output (omf remove apt 2> /dev/null)
-  end
-
-  function it_can_list_themes
-    set -l list_output (omf list -t)
-    assert 0 = $status
-    assert "$list_output" = "default"
   end
 end

--- a/pkg/omf/spec/omf_list_spec.fish
+++ b/pkg/omf/spec/omf_list_spec.fish
@@ -1,22 +1,23 @@
 function describe_omf_list_tests
   function it_can_list_plugins
     set -l list_output (omf list -p)
-    assert 0 = $status
-    assert "$list_output" = "fish-spec	omf"
+    assert_exit_code 0
+    # Built-in packages (omf, fish-spec) are not listed.
+    assert_equal "" "$list_output"
   end
 
   function it_can_list_themes
     set -l list_output (omf list -t)
-    assert 0 = $status
-    assert "$list_output" = "default"
+    assert_exit_code 0
+    assert_equal default "$list_output"
   end
 
   function it_can_list_installed_plugins
     set -l output (omf remove apt 2> /dev/null)
     set -l output (omf install apt 2> /dev/null)
     set -l list_output (omf list -p)
-    assert 0 = $status
-    assert "$list_output" = "apt		fish-spec	omf"
+    assert_exit_code 0
+    assert_equal apt "$list_output"
     set -l output (omf remove apt 2> /dev/null)
   end
 end

--- a/pkg/omf/spec/omf_packages_spec.fish
+++ b/pkg/omf/spec/omf_packages_spec.fish
@@ -1,12 +1,4 @@
 function describe_omf_packages_tests
-  function before_all
-    set -gx CI WORKAROUND
-  end
-
-  function before_all
-    set -e CI
-  end
-
   function it_can_extract_name_from_name
     set -l output (omf.packages.name foo)
     assert 0 = $status

--- a/pkg/omf/spec/omf_repositories_spec.fish
+++ b/pkg/omf/spec/omf_repositories_spec.fish
@@ -1,0 +1,59 @@
+function describe_omf_repositories
+  function before_all
+    set -g __spec_repos $OMF_CONFIG/repositories
+    set -g __spec_repos_backup (mktemp)
+    if test -f $__spec_repos
+      command cp $__spec_repos $__spec_repos_backup
+    end
+  end
+
+  function after_all
+    if test -s $__spec_repos_backup
+      command cp $__spec_repos_backup $__spec_repos
+    else
+      command rm -f $__spec_repos
+    end
+    command rm -f $__spec_repos_backup
+    set -e __spec_repos __spec_repos_backup
+  end
+
+  function it_refuses_to_add_a_builtin_repository
+    omf.index.repositories add https://github.com/oh-my-fish/packages-main master 2>/dev/null
+    assert_exit_code 1
+  end
+
+  function it_removes_only_the_exact_repository
+    command rm -f $__spec_repos
+    echo "https://example.com/a main" > $__spec_repos
+    echo "https://example.com/a-b main" >> $__spec_repos
+    omf.index.repositories remove https://example.com/a main
+    assert_exit_code 0
+    assert_not_file_contains_regex $__spec_repos '^https://example.com/a main$'
+    assert_file_contains_regex $__spec_repos '^https://example.com/a-b main$'
+  end
+
+  function it_matches_the_whole_line_when_removing
+    command rm -f $__spec_repos
+    echo "https://example.com/a main" > $__spec_repos
+    echo "https://example.com/a main-old" >> $__spec_repos
+    omf.index.repositories remove https://example.com/a main
+    assert_exit_code 0
+    assert_not_file_contains_regex $__spec_repos '^https://example.com/a main$'
+    assert_file_contains_regex $__spec_repos '^https://example.com/a main-old$'
+  end
+
+  function it_matches_the_whole_line_when_adding
+    command rm -f $__spec_repos
+    echo "https://example.com/a main-old" > $__spec_repos
+    # `git ls-remote` on the fake URL fails, so a refusal must come from the
+    # duplicate check to be wrong; success here means it got past that check.
+    omf.index.repositories add https://example.com/a main 2>&1 | string match -q '*could not be found*'
+    assert_exit_code 0
+  end
+
+  function it_reports_an_unknown_repository_on_remove
+    command rm -f $__spec_repos
+    omf.index.repositories remove https://example.com/nope main 2>/dev/null
+    assert_exit_code 1
+  end
+end

--- a/pkg/omf/spec/omf_valid_name_spec.fish
+++ b/pkg/omf/spec/omf_valid_name_spec.fish
@@ -1,0 +1,39 @@
+function describe_omf_packages_valid_name
+  function it_accepts_lowercase_names
+    omf.packages.valid_name bass
+    assert_exit_code 0
+    omf.packages.valid_name theme-bobthefish
+    assert_exit_code 0
+    omf.packages.valid_name foo.bar_baz
+    assert_exit_code 0
+  end
+
+  function it_accepts_names_starting_with_uppercase_or_digit
+    omf.packages.valid_name Bass
+    assert_exit_code 0
+    omf.packages.valid_name 2fa
+    assert_exit_code 0
+  end
+
+  function it_rejects_reserved_names
+    omf.packages.valid_name omf
+    assert_exit_code 10
+    omf.packages.valid_name OMF
+    assert_exit_code 10
+    omf.packages.valid_name default
+    assert_exit_code 10
+  end
+
+  function it_rejects_names_with_unsafe_characters
+    omf.packages.valid_name "foo/bar"
+    assert_exit_code 10
+    omf.packages.valid_name "foo bar"
+    assert_exit_code 10
+    omf.packages.valid_name "foo&bar"
+    assert_exit_code 10
+    omf.packages.valid_name "-foo"
+    assert_exit_code 10
+    omf.packages.valid_name ""
+    assert_exit_code 10
+  end
+end

--- a/tests/run.fish
+++ b/tests/run.fish
@@ -1,26 +1,67 @@
 #!/usr/bin/env fish
+#
+# Run the Oh My Fish test suite in an isolated sandbox.
+#
+# A throwaway HOME (plus XDG_* directories) is created, Oh My Fish is
+# installed into it from this checkout, and the smoke tests and fish-spec
+# suites run against that installation. The user's real Oh My Fish
+# configuration is never read or modified.
+#
+# Usage: tests/run.fish [spec files...]
+#   With no arguments, runs every spec under pkg/{fish-spec,omf}/spec.
 
-# TODO: This is only a basic draft.
-
+set -l repo (cd (dirname (status -f))/..; and pwd)
+set -l sandbox (mktemp -d)
 set -l return_code 0
 
-omf list | grep apt 2>&1 >/dev/null
-set -l apt_installed_previously $status
-
-if test $apt_installed_previously -eq 0
-  omf remove apt
+function __omf_tests_cleanup --on-event omf_tests_done -V sandbox
+  command rm -rf "$sandbox"
 end
 
-set commands "omf help" "omf doctor" "omf install apt"
-for cmd in $commands
+# Redirect every path Oh My Fish and fish itself may touch into the sandbox.
+set -lx HOME "$sandbox"
+set -lx XDG_CONFIG_HOME "$sandbox/.config"
+set -lx XDG_DATA_HOME "$sandbox/.local/share"
+set -lx XDG_CACHE_HOME "$sandbox/.cache"
+set -e OMF_PATH
+set -e OMF_CONFIG
+
+echo "Sandbox: $sandbox"
+
+if not fish "$repo/bin/install" --offline="$repo" --noninteractive --yes
+  echo "Failed to install Oh My Fish into the sandbox" >&2
+  emit omf_tests_done
+  exit 1
+end
+
+# Every command below runs in a fresh fish that boots from the sandbox
+# config, exactly as a user's shell would. An offline install skips the
+# bundle, so `omf install` first fetches the default theme.
+set -l smoke_commands "omf install" "omf help" "omf doctor" "omf install apt" "omf remove apt"
+for cmd in $smoke_commands
   echo \$ $cmd
-  if not eval $cmd
+  if not fish -c "$cmd"
+    echo "Smoke test failed: $cmd" >&2
     set return_code 1
   end
 end
 
-if test $apt_installed_previously -ne 0
-  omf remove apt
+set -l specs
+for spec in $argv
+  # Absolute paths, so they resolve the same way inside the sandboxed shell.
+  set specs $specs (cd (dirname $spec); and pwd)/(basename $spec)
+end
+if test (count $specs) -eq 0
+  set specs $repo/pkg/{fish-spec,omf}/spec/*_spec.fish
 end
 
+# `fish -c` only receives positional arguments as $argv since fish 3.1, so
+# hand the file list over through a file instead.
+printf '%s\n' $specs > "$sandbox/specs"
+set -lx OMF_TEST_SPECS_FILE "$sandbox/specs"
+if not fish -c 'fish-spec (cat $OMF_TEST_SPECS_FILE)'
+  set return_code 1
+end
+
+emit omf_tests_done
 exit $return_code


### PR DESCRIPTION
# Description

Stacked on #969 (includes #966, #969). Installs git in the Alpine-based `ohmyfish/fish` images for fish ≥ 4.1 *before* checkout — without it, `actions/checkout` silently falls back to a tarball and the tests run on a checkout with no `.git`.

- Linux matrix extended from 4.0.0 to every 4.x minor up to 4.8.0 (`ohmyfish/fish` images exist for all of them).
- macOS: `macos-14` is deprecated and `macos-latest` already aliases `macos-26`, so run on `macos-15` and `macos-26`.
- New lint job: `fish --no-execute` on every `.fish` file and `bin/install` (one file per call — fish only checks its first argument), plus verification of `bin/install.sha256`.
- `actions/checkout` v4 → v7; `permissions`, `concurrency`, `timeout-minutes`.
- `Dockerfile` pinned fish 2.5.0, below the installer's 3.0.0 minimum, so it could not build.

**Environment report**

```
OS type:              Darwin (macOS 27)
Fish version:         fish, version 4.8.1
Git version:          git version 2.55.0
Git core.autocrlf:    no
Checking for a sane environment...
Your shell is ready to swim.
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing tests pass locally with my changes

https://claude.ai/code/session_01CbqrmCn2mDNML6uRTaZVEw